### PR TITLE
Use OpenAI and Pinecone SDKs for RAG

### DIFF
--- a/server/docs/rag-chatbot.md
+++ b/server/docs/rag-chatbot.md
@@ -1,0 +1,120 @@
+# RAG Chatbot Overview
+
+## Components
+- **src/rag/prompts.ts** — Central system prompt injected on every OpenAI call.
+- **src/rag/openai.ts** — Lightweight HTTP client for OpenAI chat completions and embeddings with automatic system prompt injection and optional streaming support.
+- **src/rag/pinecone.ts** — Minimal Pinecone REST helper that resolves the index host dynamically and exposes query/upsert/delete helpers plus metadata filters.
+- **src/rag/answer.service.ts** — Main orchestration for rate limiting, semantic cache reuse, Pinecone retrieval, OpenAI generation, cache persistence, logging, and MongoDB traces.
+- **src/rag/dietQuestionClassifier.ts** — Keyword-based fitness/health classifier that preserves the previous diet-only control flow semantics.
+- **src/rag/language.ts** — HE/EN detector with fallback notice handling.
+- **src/rag/db.ts** — Singleton repository accessors for cache, traces, sources, and rate-limit documents.
+- **src/rag/index.ts** — Exports a shared `RagAnswerService` instance.
+
+## Persistence
+- **MongoDB collections**
+  - `RagCache` (`src/models/ragCacheModel.ts`): Stores normalized questions, answers, language, citations, embedding snapshot, and reuse metadata.
+  - `RagTrace` (`src/models/ragTraceModel.ts`): Lightweight trace log for observability (question, answer preview, usage, reason).
+  - `RagRateLimit` (`src/models/ragRateLimitModel.ts`): Sliding-window timestamps for per-user rate limiting.
+  - `RagSource` (`src/models/ragSourceModel.ts`): Canonical storage for ingested context chunks with dedupe hashes.
+
+- **Repositories** under `src/repositories/Rag` wrap CRUD/upsert helpers for each model.
+
+## Lambda Surface
+- **src/controllers/ragController.ts** exposes two actions:
+  - `POST /rag/query` handles chat requests (streaming or JSON) via `ragAnswerService`.
+  - `POST /rag/ingest` upserts source chunks after verifying the provided `adminUserId` belongs to an admin.
+- **src/functions/rag/index.ts** wires the controller through the shared `handleApiCall` router.
+
+## Runtime Flow
+1. Rate limit enforcement per user (Mongo sliding window).
+2. Language detection (HE/EN/other → HE) and fallback notice setup.
+3. Semantic cache lookup (Pinecone namespace `semantic-cache` + Mongo document) with 0.9 default threshold.
+4. Fitness/health classifier gate with localized rejection message when irrelevant.
+5. Pinecone retrieval (`corpus` namespace) with lang-preferring filter, threshold fallback, and trimmed context sentences.
+6. OpenAI generation at temperature 0.2 with streaming support, citations, and fallback message when no context meets threshold.
+7. Cache persistence (Mongo + Pinecone) for successful, cited answers and trace logging for observability.
+8. Structured console log `evt: "rag.query"` summarizing latency, tokens, retrieved IDs, and reason code.
+
+## Tuning Knobs
+- Environment-driven: `RAG_RETRIEVAL_TOP_K`, `RAG_RETRIEVAL_THRESHOLD`, `RAG_CACHE_THRESHOLD`, `RAG_RATE_LIMIT_WINDOW_MS`, `RAG_RATE_LIMIT_MAX_REQUESTS`, `OPENAI_CHAT_MODEL`, `OPENAI_EMBEDDING_MODEL` (all optional).
+- Request-level: `topK`, `threshold`, `cacheThreshold`, `stream`, and metadata filters.
+- Pinecone namespaces: `semantic-cache` (cache) and `corpus` (canonical content).
+
+## Operational Notes
+- Streaming responses emit `data: {"delta"}` chunks followed by a trailer `data: {"done":true,...}`.
+- Non-streaming responses return `{ reason, answer, citations, usage, cached, notice, language }`.
+- Ingestion requires an `adminUserId` belonging to an admin user.
+- Rate limit exceedance returns HTTP 429 with `{ message: "rate limit exceeded" }`.
+- Language fallback notice: `השאלה זוהתה בשפה שאינה נתמכת, התשובה מסופקת בעברית בהתאם למדיניות.` prefixed to answers when input is neither HE nor EN.
+
+## Example Requests
+
+> Replace `YOUR_API_GATEWAY_URL` with the deployed base URL and set the `x-api-key`/authorization headers that your environment requires.
+
+### 1. English Fitness Question (JSON response)
+
+```bash
+curl -X POST "https://YOUR_API_GATEWAY_URL/rag/query" \
+  -H "Content-Type: application/json" \
+  -d '{
+        "userId": "64fabc12d9012f001234abcd",
+        "sessionId": "web-123",
+        "question": "What are three mobility drills to loosen tight hamstrings before a run?",
+        "stream": false,
+        "topK": 5,
+        "threshold": 0.55
+      }'
+```
+
+### 2. Hebrew Nutrition Question (streaming SSE)
+
+```bash
+curl -N -X POST "https://YOUR_API_GATEWAY_URL/rag/query" \
+  -H "Content-Type: application/json" \
+  -d '{
+        "userId": "64fabc12d9012f001234abcd",
+        "sessionId": "ios-442",
+        "question": "מה אפשר לאכול אחרי אימון כוח כדי לתמוך בהתאוששות?",
+        "stream": true,
+        "cacheThreshold": 0.9
+      }'
+```
+
+### 3. Non-supported Language (auto-fallback to Hebrew)
+
+```bash
+curl -X POST "https://YOUR_API_GATEWAY_URL/rag/query" \
+  -H "Content-Type: application/json" \
+  -d '{
+        "userId": "64fabc12d9012f001234abcd",
+        "sessionId": "web-987",
+        "question": "Quels exercices doux puis-je faire pendant une semaine de récupération?",
+        "stream": false
+      }'
+```
+
+Expected behavior: the answer begins with the fallback notice and continues in Hebrew with `[^i]` citations.
+
+### 4. Content Ingestion (admin only)
+
+```bash
+curl -X POST "https://YOUR_API_GATEWAY_URL/rag/ingest" \
+  -H "Content-Type: application/json" \
+  -d '{
+        "adminUserId": "64fa0000d9012f0098765432",
+        "userId": "64fabc12d9012f001234abcd",
+        "sourceId": "post-run-guide",
+        "chunks": [
+          {
+            "id": "post-run-guide-1",
+            "text": "Perform light dynamic stretches such as leg swings and walking lunges for 5-7 minutes to maintain mobility.",
+            "metadata": { "lang": "en", "tags": ["mobility", "running"] }
+          },
+          {
+            "id": "post-run-guide-2",
+            "text": "Refuel within 60 minutes with carbohydrates and 20-30 grams of protein to support glycogen replenishment and repair.",
+            "metadata": { "lang": "en", "tags": ["nutrition", "recovery"] }
+          }
+        ]
+      }'
+```

--- a/server/docs/rag-chatbot.md
+++ b/server/docs/rag-chatbot.md
@@ -1,6 +1,7 @@
 # RAG Chatbot Overview
 
 ## Components
+
 - **src/rag/prompts.ts** — Central system prompt injected on every OpenAI call.
 - **src/rag/openai.ts** — Lightweight HTTP client for OpenAI chat completions and embeddings with automatic system prompt injection and optional streaming support.
 - **src/rag/pinecone.ts** — Minimal Pinecone REST helper that resolves the index host dynamically and exposes query/upsert/delete helpers plus metadata filters.
@@ -11,6 +12,7 @@
 - **src/rag/index.ts** — Exports a shared `RagAnswerService` instance.
 
 ## Persistence
+
 - **MongoDB collections**
   - `RagCache` (`src/models/ragCacheModel.ts`): Stores normalized questions, answers, language, citations, embedding snapshot, and reuse metadata.
   - `RagTrace` (`src/models/ragTraceModel.ts`): Lightweight trace log for observability (question, answer preview, usage, reason).
@@ -20,12 +22,14 @@
 - **Repositories** under `src/repositories/Rag` wrap CRUD/upsert helpers for each model.
 
 ## Lambda Surface
+
 - **src/controllers/ragController.ts** exposes two actions:
   - `POST /rag/query` handles chat requests (streaming or JSON) via `ragAnswerService`.
   - `POST /rag/ingest` upserts source chunks after verifying the provided `adminUserId` belongs to an admin.
 - **src/functions/rag/index.ts** wires the controller through the shared `handleApiCall` router.
 
 ## Runtime Flow
+
 1. Rate limit enforcement per user (Mongo sliding window).
 2. Language detection (HE/EN/other → HE) and fallback notice setup.
 3. Semantic cache lookup (Pinecone namespace `semantic-cache` + Mongo document) with 0.9 default threshold.
@@ -36,11 +40,13 @@
 8. Structured console log `evt: "rag.query"` summarizing latency, tokens, retrieved IDs, and reason code.
 
 ## Tuning Knobs
+
 - Environment-driven: `RAG_RETRIEVAL_TOP_K`, `RAG_RETRIEVAL_THRESHOLD`, `RAG_CACHE_THRESHOLD`, `RAG_RATE_LIMIT_WINDOW_MS`, `RAG_RATE_LIMIT_MAX_REQUESTS`, `OPENAI_CHAT_MODEL`, `OPENAI_EMBEDDING_MODEL` (all optional).
 - Request-level: `topK`, `threshold`, `cacheThreshold`, `stream`, and metadata filters.
 - Pinecone namespaces: `semantic-cache` (cache) and `corpus` (canonical content).
 
 ## Operational Notes
+
 - Streaming responses emit `data: {"delta"}` chunks followed by a trailer `data: {"done":true,...}`.
 - Non-streaming responses return `{ reason, answer, citations, usage, cached, notice, language }`.
 - Ingestion requires an `adminUserId` belonging to an admin user.

--- a/server/docs/rag-frontend-integration.md
+++ b/server/docs/rag-frontend-integration.md
@@ -1,0 +1,128 @@
+# Frontend Integration Guide: Fitness RAG Chatbot
+
+This guide explains how client applications integrate with the Lambda-backed RAG chatbot, including payload formats, streaming tips, and how to surface citations and notices to end users.
+
+## Endpoints
+
+| Method & Path | Purpose |
+| --- | --- |
+| `POST /rag/query` | Submit a user question and receive either a JSON payload or a streaming SSE response. |
+| `POST /rag/ingest` | Admin-only ingestion of curated context chunks for a user’s private corpus. |
+
+Attach the same authentication headers required by the rest of your API Gateway stack (JWT, API key, etc.). Every query must supply a `userId`; the backend enforces per-user rate limits entirely in MongoDB.
+
+## Query Request Payload
+
+```json
+{
+  "userId": "<mongo-id>",
+  "sessionId": "optional-client-session",
+  "question": "string",
+  "stream": true,
+  "topK": 5,
+  "threshold": 0.55,
+  "cacheThreshold": 0.9,
+  "metadata": { "goal": "hypertrophy" }
+}
+```
+
+Field notes:
+- `stream` toggles Server-Sent Events (default `false`).
+- `topK`, `threshold`, and `cacheThreshold` override the environment defaults when present.
+- `metadata` passes through to Pinecone filters alongside the built-in user/language filters.
+
+The controller extracts these fields and forwards them to `RagAnswerService` for processing.【F:server/src/controllers/ragController.ts†L27-L69】 Missing `userId` or `question` produces HTTP 400.【F:server/src/rag/answer.service.ts†L196-L205】
+
+## Non-Streaming Responses
+
+When `stream` is `false`, the Lambda returns JSON:
+
+```json
+{
+  "reason": "ANSWER_GENERATED",
+  "answer": "...text with [^1] markers...",
+  "citations": [
+    { "marker": "[^1]", "sourceId": "plan-1", "page": 2, "score": 0.78 }
+  ],
+  "usage": { "promptTokens": 123, "completionTokens": 98, "totalTokens": 221 },
+  "cached": false,
+  "notice": "optional fallback notice",
+  "language": "he"
+}
+```
+
+- `reason` reveals the flow branch (`CACHE_HIT`, `NOT_FITNESS`, `RETRIEVAL_EMPTY`, `ANSWER_GENERATED`).【F:server/src/rag/types.ts†L5-L49】
+- `answer` already contains inline `[^i]` markers that correspond to the `citations` array order.【F:server/src/rag/answer.service.ts†L389-L455】
+- `notice` surfaces only when the service defaulted to Hebrew because the input language was unsupported.【F:server/src/rag/answer.service.ts†L396-L430】
+- `language` echoes the detected/target language for display logic.【F:server/src/controllers/ragController.ts†L55-L63】
+
+Rate-limit violations respond with HTTP 429 and `{ "message": "rate limit exceeded" }`.【F:server/src/rag/answer.service.ts†L55-L90】
+
+## Streaming with Server-Sent Events
+
+Set `stream: true` to receive newline-delimited SSE frames (`Content-Type: text/event-stream`).【F:server/src/controllers/ragController.ts†L34-L53】 Client responsibilities:
+
+1. Open a streaming `fetch`/`EventSource` request and read the response body incrementally.
+2. For each `data: ...` line, JSON-decode the payload.
+3. Append `payload.delta` tokens to the transcript.
+4. Watch for the final trailer where `payload.done === true`; extract `citations` and `usage`, then close the stream.
+
+Example frame sequence:
+
+```
+data: {"delta":"השאלה זוהתה..."}
+
+data: {"delta":"● בצעו..."}
+
+data: {"done":true,"citations":[{"marker":"[^1]","sourceId":"plan-1"}],"usage":{"promptTokens":120,"completionTokens":95,"totalTokens":215}}
+```
+
+Cache hits stream the cached answer followed by the trailer—no `usage` object is present because OpenAI was not called.【F:server/src/rag/answer.service.ts†L216-L269】 If retrieval scores never cross the threshold, the service emits a localized “I don’t know from the provided context.” message and ends the stream immediately.【F:server/src/rag/answer.service.ts†L331-L386】
+
+## Language Policy for Frontend UX
+
+Language detection prefers Hebrew or English and falls back to Hebrew (with a notice) for all other inputs.【F:server/src/rag/language.ts†L1-L30】 When a fallback occurs, the service prepends the policy notice to streamed and buffered answers and returns it in `notice` as well.【F:server/src/rag/answer.service.ts†L396-L430】 UI tips:
+
+- Display the notice prominently (banner or toast).
+- Render the answer verbatim—no extra translation or marker stripping.
+- Keep `[^…]` markers in place so they align with the citations list.
+
+## Citations & Context
+
+Citations include `marker`, `sourceId`, optional `page`, and the Pinecone `score`. They are generated in the same order as the trimmed context blocks sent to OpenAI.【F:server/src/rag/answer.service.ts†L389-L407】【F:server/src/rag/answer.service.ts†L441-L455】 Present them alongside the answer (e.g., numbered list) and map `sourceId` to human-friendly titles from your content catalog.
+
+## Semantic Cache Awareness
+
+Before retrieval, the service embeds the normalized question and queries the semantic cache namespace. A match above the configured threshold returns immediately with `reason: "CACHE_HIT"`, `cached: true`, and the stored citations—no new tokens spent.【F:server/src/rag/answer.service.ts†L202-L269】 Consider showing a subtle “answered from cache” hint in the UI when `cached` is true.
+
+## Error Handling Summary
+
+| Status | Cause | UI Suggestion |
+| --- | --- | --- |
+| 400 | Missing `userId`/`question` or malformed ingest payload | Prompt user to correct the form. |
+| 403 | Ingest attempted without admin privileges | Show “Admins only” message. |
+| 429 | Rate limit exceeded in the current 60s window | Display a cooldown timer or retry CTA. |
+| 500 | Unexpected backend failure | Offer retry and log the incident. |
+
+Source references: validation and rate limit enforcement in `RagAnswerService`, admin guard in `RagController`.【F:server/src/rag/answer.service.ts†L55-L90】【F:server/src/rag/answer.service.ts†L528-L559】【F:server/src/controllers/ragController.ts†L18-L101】
+
+All responses include the standard API headers; streaming adds SSE headers for EventSource compatibility.【F:server/src/controllers/ragController.ts†L44-L53】
+
+## Ingestion Workflow (Admin UI)
+
+Admins provide `userId`, `sourceId`, `lang`, visibility, and chunk payloads. The service normalizes whitespace, deduplicates via SHA-256 hashes, stores chunks in Mongo, and mirrors embeddings into the Pinecone `corpus` namespace before returning `{ "inserted": <count> }`.【F:server/src/rag/answer.service.ts†L536-L598】
+
+## Observability Hooks
+
+Each query logs a structured event containing reason, language, latency, retrieved IDs, and token usage, and persists a Mongo trace for offline evaluation.【F:server/src/rag/answer.service.ts†L237-L515】 Align your client telemetry (e.g., session IDs) with the `sessionId` field to simplify cross-system debugging.
+
+## Implementation Checklist
+
+1. **Authentication:** Reuse the existing API auth headers for every request.
+2. **Request Builder:** Capture the question, `userId`, optional filters, and desired streaming mode.
+3. **Streaming Parser:** Implement an SSE reader that yields `delta` tokens and final trailer metadata.
+4. **UI Rendering:** Preserve the answer text with its `[^…]` markers, show `notice` when provided, and render citations alongside the reply.
+5. **Error UX:** Handle 4xx/5xx responses gracefully (cooldown timers, retry flows, support links).
+6. **Admin Tools:** Offer a simple form or script for `/rag/ingest` that batches curated chunks and reports inserted counts.
+
+Following these steps keeps the frontend aligned with semantic caching, HE/EN language policy, and the chatbot’s citation contract.

--- a/server/docs/rag-frontend-integration.md
+++ b/server/docs/rag-frontend-integration.md
@@ -4,10 +4,10 @@ This guide explains how client applications integrate with the Lambda-backed RAG
 
 ## Endpoints
 
-| Method & Path | Purpose |
-| --- | --- |
-| `POST /rag/query` | Submit a user question and receive either a JSON payload or a streaming SSE response. |
-| `POST /rag/ingest` | Admin-only ingestion of curated context chunks for a user’s private corpus. |
+| Method & Path      | Purpose                                                                               |
+| ------------------ | ------------------------------------------------------------------------------------- |
+| `POST /rag/query`  | Submit a user question and receive either a JSON payload or a streaming SSE response. |
+| `POST /rag/ingest` | Admin-only ingestion of curated context chunks for a user’s private corpus.           |
 
 Attach the same authentication headers required by the rest of your API Gateway stack (JWT, API key, etc.). Every query must supply a `userId`; the backend enforces per-user rate limits entirely in MongoDB.
 
@@ -27,6 +27,7 @@ Attach the same authentication headers required by the rest of your API Gateway 
 ```
 
 Field notes:
+
 - `stream` toggles Server-Sent Events (default `false`).
 - `topK`, `threshold`, and `cacheThreshold` override the environment defaults when present.
 - `metadata` passes through to Pinecone filters alongside the built-in user/language filters.
@@ -41,9 +42,7 @@ When `stream` is `false`, the Lambda returns JSON:
 {
   "reason": "ANSWER_GENERATED",
   "answer": "...text with [^1] markers...",
-  "citations": [
-    { "marker": "[^1]", "sourceId": "plan-1", "page": 2, "score": 0.78 }
-  ],
+  "citations": [{ "marker": "[^1]", "sourceId": "plan-1", "page": 2, "score": 0.78 }],
   "usage": { "promptTokens": 123, "completionTokens": 98, "totalTokens": 221 },
   "cached": false,
   "notice": "optional fallback notice",
@@ -97,12 +96,12 @@ Before retrieval, the service embeds the normalized question and queries the sem
 
 ## Error Handling Summary
 
-| Status | Cause | UI Suggestion |
-| --- | --- | --- |
-| 400 | Missing `userId`/`question` or malformed ingest payload | Prompt user to correct the form. |
-| 403 | Ingest attempted without admin privileges | Show “Admins only” message. |
-| 429 | Rate limit exceeded in the current 60s window | Display a cooldown timer or retry CTA. |
-| 500 | Unexpected backend failure | Offer retry and log the incident. |
+| Status | Cause                                                   | UI Suggestion                          |
+| ------ | ------------------------------------------------------- | -------------------------------------- |
+| 400    | Missing `userId`/`question` or malformed ingest payload | Prompt user to correct the form.       |
+| 403    | Ingest attempted without admin privileges               | Show “Admins only” message.            |
+| 429    | Rate limit exceeded in the current 60s window           | Display a cooldown timer or retry CTA. |
+| 500    | Unexpected backend failure                              | Offer retry and log the incident.      |
 
 Source references: validation and rate limit enforcement in `RagAnswerService`, admin guard in `RagController`.【F:server/src/rag/answer.service.ts†L55-L90】【F:server/src/rag/answer.service.ts†L528-L559】【F:server/src/controllers/ragController.ts†L18-L101】
 

--- a/server/package.json
+++ b/server/package.json
@@ -13,11 +13,13 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@pinecone-database/pinecone": "^3.1.0",
     "aws-sdk": "^2.1690.0",
     "bcryptjs": "^2.4.3",
     "joi": "^17.6.0",
     "mongoose": "^8.16.5",
-    "nodemailer": "^7.0.5"
+    "nodemailer": "^7.0.5",
+    "openai": "^4.28.0"
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.145",

--- a/server/src/controllers/ragController.ts
+++ b/server/src/controllers/ragController.ts
@@ -1,0 +1,103 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
+import { ragAnswerService } from "../rag";
+import { extractBodyFromEvent } from "../utils/utils";
+import { StatusCode } from "../enums/StatusCode";
+import { API_HEADERS } from "../constants/Constants";
+import { RagRequest } from "../rag/types";
+import UserService from "../services/userService";
+import { requireAdmin } from "../guards/AdminAccessGuard";
+
+const userService = new UserService();
+
+const SSE_HEADERS = {
+  "Content-Type": "text/event-stream",
+  "Cache-Control": "no-cache",
+  Connection: "close",
+};
+
+const ensureAdmin = async (adminUserId?: string) => {
+  if (!adminUserId) {
+    throw { status: StatusCode.FORBIDDEN, message: "admin privileges required" };
+  }
+  const admin = await userService.findById(adminUserId);
+  requireAdmin(admin as any);
+};
+
+export class RagController {
+  ask = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+    try {
+      const body = extractBodyFromEvent(event);
+      const request: RagRequest = {
+        userId: body.userId,
+        question: body.question,
+        sessionId: body.sessionId,
+        stream: Boolean(body.stream),
+        topK: typeof body.topK === "number" ? body.topK : undefined,
+        threshold: typeof body.threshold === "number" ? body.threshold : undefined,
+        cacheThreshold:
+          typeof body.cacheThreshold === "number" ? body.cacheThreshold : undefined,
+        metadata: body.metadata,
+      };
+
+      const result = await ragAnswerService.answerQuestion(request);
+
+      if (request.stream) {
+        return {
+          statusCode: StatusCode.OK,
+          body: (result.events || []).join(""),
+          headers: {
+            ...API_HEADERS,
+            ...SSE_HEADERS,
+          },
+        };
+      }
+
+      const payload = {
+        reason: result.response.reason,
+        answer: result.response.answer,
+        citations: result.response.citations,
+        usage: result.response.usage,
+        cached: result.response.cached,
+        notice: result.response.notice,
+        language: result.languageDetection.targetLanguage,
+      };
+
+      return {
+        statusCode: StatusCode.OK,
+        body: JSON.stringify(payload),
+        headers: API_HEADERS,
+      };
+    } catch (error: any) {
+      console.error("rag.ask error", error);
+      const status = error?.status || StatusCode.INTERNAL_SERVER_ERROR;
+      const message = error?.message || "Failed to process request";
+      return {
+        statusCode: status,
+        body: JSON.stringify({ message }),
+        headers: API_HEADERS,
+      };
+    }
+  };
+
+  ingest = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+    try {
+      const body = extractBodyFromEvent(event);
+      await ensureAdmin(body.adminUserId);
+      const result = await ragAnswerService.ingest(body);
+      return {
+        statusCode: StatusCode.OK,
+        body: JSON.stringify({ message: "ingest completed", data: result }),
+        headers: API_HEADERS,
+      };
+    } catch (error: any) {
+      console.error("rag.ingest error", error);
+      const status = error?.status || StatusCode.INTERNAL_SERVER_ERROR;
+      const message = error?.message || "Failed to ingest sources";
+      return {
+        statusCode: status,
+        body: JSON.stringify({ message }),
+        headers: API_HEADERS,
+      };
+    }
+  };
+}

--- a/server/src/controllers/ragController.ts
+++ b/server/src/controllers/ragController.ts
@@ -34,8 +34,7 @@ export class RagController {
         stream: Boolean(body.stream),
         topK: typeof body.topK === "number" ? body.topK : undefined,
         threshold: typeof body.threshold === "number" ? body.threshold : undefined,
-        cacheThreshold:
-          typeof body.cacheThreshold === "number" ? body.cacheThreshold : undefined,
+        cacheThreshold: typeof body.cacheThreshold === "number" ? body.cacheThreshold : undefined,
         metadata: body.metadata,
       };
 

--- a/server/src/functions/rag/index.ts
+++ b/server/src/functions/rag/index.ts
@@ -1,0 +1,18 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult, Context } from "aws-lambda";
+import { handleApiCall } from "../baseHandler";
+import { RagController } from "../../controllers/ragController";
+
+const BASE_PATH = "/rag";
+const controller = new RagController();
+
+const handlers = {
+  [`POST ${BASE_PATH}/query`]: controller.ask,
+  [`POST ${BASE_PATH}/ingest`]: controller.ingest,
+};
+
+export const handler = async (
+  event: APIGatewayProxyEvent,
+  context: Context
+): Promise<APIGatewayProxyResult> => {
+  return await handleApiCall(event, context, handlers);
+};

--- a/server/src/models/ragCacheModel.ts
+++ b/server/src/models/ragCacheModel.ts
@@ -1,0 +1,55 @@
+import { Schema, model } from "mongoose";
+
+export interface IRagCitation {
+  marker: string;
+  sourceId: string;
+  page?: number;
+  score?: number;
+}
+
+export interface IRagCacheEntry {
+  userId: string;
+  question: string;
+  normalizedQuestion: string;
+  answer: string;
+  language: "he" | "en";
+  citations: IRagCitation[];
+  retrievedIds: string[];
+  topScore: number;
+  embedding: number[];
+  refusal: boolean;
+  notice?: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const ragCacheSchema = new Schema<IRagCacheEntry>(
+  {
+    userId: { type: String, required: true, index: true },
+    question: { type: String, required: true },
+    normalizedQuestion: { type: String, required: true },
+    answer: { type: String, required: true },
+    language: { type: String, enum: ["he", "en"], required: true },
+    citations: [
+      {
+        marker: { type: String, required: true },
+        sourceId: { type: String, required: true },
+        page: { type: Number },
+        score: { type: Number },
+      },
+    ],
+    retrievedIds: { type: [String], default: [] },
+    topScore: { type: Number, default: 0 },
+    embedding: { type: [Number], default: [] },
+    refusal: { type: Boolean, default: false },
+    notice: { type: String },
+  },
+  { timestamps: true }
+);
+
+ragCacheSchema.index({ userId: 1, normalizedQuestion: 1 }, { unique: true });
+ragCacheSchema.index({ updatedAt: -1 });
+
+const RagCacheModel = model<IRagCacheEntry>("RagCache", ragCacheSchema);
+
+export default RagCacheModel;

--- a/server/src/models/ragRateLimitModel.ts
+++ b/server/src/models/ragRateLimitModel.ts
@@ -1,0 +1,20 @@
+import { Schema, model } from "mongoose";
+
+export interface IRagRateLimit {
+  userId: string;
+  events: Date[];
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const ragRateLimitSchema = new Schema<IRagRateLimit>(
+  {
+    userId: { type: String, required: true, unique: true },
+    events: { type: [Date], default: [] },
+  },
+  { timestamps: true }
+);
+
+const RagRateLimitModel = model<IRagRateLimit>("RagRateLimit", ragRateLimitSchema);
+
+export default RagRateLimitModel;

--- a/server/src/models/ragSourceModel.ts
+++ b/server/src/models/ragSourceModel.ts
@@ -1,0 +1,35 @@
+import { Schema, model } from "mongoose";
+
+export interface IRagSourceChunk {
+  userId: string;
+  sourceId: string;
+  chunkId: string;
+  text: string;
+  hash: string;
+  metadata?: Record<string, any>;
+  lang: string;
+  visibility: "private" | "shared";
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const ragSourceSchema = new Schema<IRagSourceChunk>(
+  {
+    userId: { type: String, required: true, index: true },
+    sourceId: { type: String, required: true, index: true },
+    chunkId: { type: String, required: true },
+    text: { type: String, required: true },
+    hash: { type: String, required: true },
+    metadata: { type: Schema.Types.Mixed },
+    lang: { type: String, default: "en" },
+    visibility: { type: String, enum: ["private", "shared"], default: "private" },
+  },
+  { timestamps: true }
+);
+
+ragSourceSchema.index({ userId: 1, sourceId: 1, chunkId: 1 }, { unique: true });
+ragSourceSchema.index({ hash: 1, userId: 1 });
+
+const RagSourceModel = model<IRagSourceChunk>("RagSource", ragSourceSchema);
+
+export default RagSourceModel;

--- a/server/src/models/ragTraceModel.ts
+++ b/server/src/models/ragTraceModel.ts
@@ -1,0 +1,42 @@
+import { Schema, model } from "mongoose";
+
+export interface IRagTrace {
+  userId: string;
+  sessionId?: string;
+  question: string;
+  language: string;
+  retrievedIds: string[];
+  reason: string;
+  answerPreview: string;
+  usage?: {
+    promptTokens: number;
+    completionTokens: number;
+    totalTokens: number;
+  };
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const ragTraceSchema = new Schema<IRagTrace>(
+  {
+    userId: { type: String, required: true, index: true },
+    sessionId: { type: String },
+    question: { type: String, required: true },
+    language: { type: String, required: true },
+    retrievedIds: { type: [String], default: [] },
+    reason: { type: String, required: true },
+    answerPreview: { type: String, required: true },
+    usage: {
+      promptTokens: Number,
+      completionTokens: Number,
+      totalTokens: Number,
+    },
+  },
+  { timestamps: true }
+);
+
+ragTraceSchema.index({ createdAt: -1 });
+
+const RagTraceModel = model<IRagTrace>("RagTrace", ragTraceSchema);
+
+export default RagTraceModel;

--- a/server/src/rag/answer.service.ts
+++ b/server/src/rag/answer.service.ts
@@ -35,8 +35,7 @@ const traceRepository = getRagTraceRepository();
 const rateLimitRepository = getRagRateLimitRepository();
 const sourceRepository = getRagSourceRepository();
 
-const toSseChunk = (payload: Record<string, any>) =>
-  `data: ${JSON.stringify(payload)}\n\n`;
+const toSseChunk = (payload: Record<string, any>) => `data: ${JSON.stringify(payload)}\n\n`;
 
 const buildCitations = (matches: PineconeMatch[]): Citation[] =>
   matches.map((match, index) => ({
@@ -64,9 +63,7 @@ const ensureRateLimit = async (userId: string) => {
     record = null;
   }
 
-  const filteredEvents = (record?.events || []).filter((event) =>
-    event > windowStart
-  );
+  const filteredEvents = (record?.events || []).filter((event) => event > windowStart);
 
   if (filteredEvents.length >= RAG_CONSTANTS.rateLimitMaxRequests) {
     throw { status: StatusCode.TOO_MANY_REQUESTS, message: "rate limit exceeded" };
@@ -75,10 +72,13 @@ const ensureRateLimit = async (userId: string) => {
   filteredEvents.push(now);
 
   if (record) {
-    await rateLimitRepository.updateOne({ userId } as any, {
-      events: filteredEvents,
-      updatedAt: now,
-    } as any);
+    await rateLimitRepository.updateOne(
+      { userId } as any,
+      {
+        events: filteredEvents,
+        updatedAt: now,
+      } as any
+    );
   } else {
     await rateLimitRepository.create({
       userId,
@@ -127,11 +127,7 @@ const findCacheHit = async (
   return null;
 };
 
-const storeCacheHit = async (
-  doc: IRagCacheEntry,
-  embedding: number[],
-  userId: string
-) => {
+const storeCacheHit = async (doc: IRagCacheEntry, embedding: number[], userId: string) => {
   const stored = await cacheRepository.upsertCacheEntry(doc);
   if (!stored) return;
   const cacheId = String((stored as any)?._id || doc.normalizedQuestion);
@@ -269,13 +265,11 @@ export class RagAnswerService {
       };
     }
 
-    const classification = classifyQuestion(
-      normalizedQuestion,
-      languageDetection.targetLanguage
-    );
+    const classification = classifyQuestion(normalizedQuestion, languageDetection.targetLanguage);
 
     if (!classification.isFitness) {
-      const message = classification.message || NOT_FITNESS_MESSAGES[languageDetection.targetLanguage];
+      const message =
+        classification.message || NOT_FITNESS_MESSAGES[languageDetection.targetLanguage];
       const response: RagResponse = {
         reason: "NOT_FITNESS",
         answer: message,

--- a/server/src/rag/answer.service.ts
+++ b/server/src/rag/answer.service.ts
@@ -1,0 +1,600 @@
+import { createHash } from "crypto";
+import { StatusCode } from "../enums/StatusCode";
+import { detectLanguage } from "./language";
+import { classifyQuestion, NOT_FITNESS_MESSAGES } from "./dietQuestionClassifier";
+import { createEmbedding, generateAnswer } from "./openai";
+import {
+  buildMetadataFilter,
+  queryPinecone,
+  trimMatches,
+  upsertVectors,
+  PineconeMatch,
+} from "./pinecone";
+import { normalizeText, summariseSentences } from "./text";
+import { RAG_CONSTANTS } from "./config";
+import {
+  getRagCacheRepository,
+  getRagRateLimitRepository,
+  getRagSourceRepository,
+  getRagTraceRepository,
+} from "./db";
+import {
+  Citation,
+  RagIngestRequest,
+  RagReason,
+  RagRequest,
+  RagResponse,
+  RagStreamTrailer,
+} from "./types";
+import RagRateLimitModel, { IRagRateLimit } from "../models/ragRateLimitModel";
+import { IRagCacheEntry } from "../models/ragCacheModel";
+import { UsageMetrics } from "./openai";
+
+const cacheRepository = getRagCacheRepository();
+const traceRepository = getRagTraceRepository();
+const rateLimitRepository = getRagRateLimitRepository();
+const sourceRepository = getRagSourceRepository();
+
+const toSseChunk = (payload: Record<string, any>) =>
+  `data: ${JSON.stringify(payload)}\n\n`;
+
+const buildCitations = (matches: PineconeMatch[]): Citation[] =>
+  matches.map((match, index) => ({
+    marker: `[^${index + 1}]`,
+    sourceId: String(match.metadata?.sourceId || match.id),
+    page: match.metadata?.page,
+    score: match.score,
+  }));
+
+const buildContextBlocks = (matches: PineconeMatch[]): string[] =>
+  matches.map((match, index) => {
+    const text = match.metadata?.text || "";
+    return `[${index + 1}] ${summariseSentences(text, RAG_CONSTANTS.minContextSentences)}`;
+  });
+
+const ensureRateLimit = async (userId: string) => {
+  const now = new Date();
+  const windowStart = new Date(now.getTime() - RAG_CONSTANTS.rateLimitWindowMs);
+
+  let record: IRagRateLimit | null = null;
+
+  try {
+    record = await RagRateLimitModel.findOne({ userId }).lean();
+  } catch (error) {
+    record = null;
+  }
+
+  const filteredEvents = (record?.events || []).filter((event) =>
+    event > windowStart
+  );
+
+  if (filteredEvents.length >= RAG_CONSTANTS.rateLimitMaxRequests) {
+    throw { status: StatusCode.TOO_MANY_REQUESTS, message: "rate limit exceeded" };
+  }
+
+  filteredEvents.push(now);
+
+  if (record) {
+    await rateLimitRepository.updateOne({ userId } as any, {
+      events: filteredEvents,
+      updatedAt: now,
+    } as any);
+  } else {
+    await rateLimitRepository.create({
+      userId,
+      events: filteredEvents,
+      createdAt: now,
+      updatedAt: now,
+    } as any);
+  }
+};
+
+const cacheVectorId = (cacheId: string, userId: string) => `cache-${userId}-${cacheId}`;
+
+const findCacheHit = async (
+  userId: string,
+  embedding: number[],
+  cacheThreshold: number,
+  language: string
+): Promise<IRagCacheEntry | null> => {
+  const matches = await queryPinecone({
+    namespace: RAG_CONSTANTS.cacheNamespace,
+    topK: 3,
+    vector: embedding,
+    filter: buildMetadataFilter(userId, language),
+  });
+
+  if (!matches.length) return null;
+
+  const [best] = matches;
+  if (!best || (best.score || 0) < cacheThreshold) {
+    return null;
+  }
+
+  const cacheId = best.metadata?.cacheId as string | undefined;
+  if (cacheId) {
+    const cacheDoc = await cacheRepository.findByIdLean(cacheId);
+    if (cacheDoc) {
+      return cacheDoc;
+    }
+  }
+
+  const normalizedQuestion = best.metadata?.normalizedQuestion as string | undefined;
+  if (normalizedQuestion) {
+    return await cacheRepository.findByNormalizedQuestion(userId, normalizedQuestion);
+  }
+
+  return null;
+};
+
+const storeCacheHit = async (
+  doc: IRagCacheEntry,
+  embedding: number[],
+  userId: string
+) => {
+  const stored = await cacheRepository.upsertCacheEntry(doc);
+  if (!stored) return;
+  const cacheId = String((stored as any)?._id || doc.normalizedQuestion);
+  await upsertVectors(RAG_CONSTANTS.cacheNamespace, [
+    {
+      id: cacheVectorId(cacheId, userId),
+      values: embedding,
+      metadata: {
+        userId,
+        lang: doc.language,
+        normalizedQuestion: doc.normalizedQuestion,
+        cacheId,
+        retrievedIds: doc.retrievedIds,
+        topScore: doc.topScore,
+      },
+    },
+  ]);
+};
+
+const logTrace = async (
+  userId: string,
+  question: string,
+  language: string,
+  reason: RagReason,
+  answer: string,
+  retrievedIds: string[],
+  usage?: UsageMetrics,
+  sessionId?: string
+) => {
+  const preview = answer.length > 280 ? `${answer.slice(0, 277)}...` : answer;
+  await traceRepository.create({
+    userId,
+    sessionId,
+    question,
+    language,
+    reason,
+    retrievedIds,
+    answerPreview: preview,
+    usage,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  } as any);
+};
+
+const computeHash = (text: string) =>
+  createHash("sha256").update(normalizeText(text)).digest("hex");
+
+export class RagAnswerService {
+  async answerQuestion(request: RagRequest) {
+    const start = Date.now();
+    const {
+      userId,
+      question,
+      sessionId,
+      stream = false,
+      topK,
+      threshold,
+      cacheThreshold,
+      metadata = {},
+    } = request;
+
+    if (!userId || !question) {
+      throw { status: StatusCode.BAD_REQUEST, message: "userId and question are required" };
+    }
+
+    await ensureRateLimit(userId);
+
+    const languageDetection = detectLanguage(question);
+    const normalizedQuestion = normalizeText(question);
+    const embedding = await createEmbedding(normalizedQuestion);
+
+    const effectiveCacheThreshold =
+      typeof cacheThreshold === "number" ? cacheThreshold : RAG_CONSTANTS.defaultCacheThreshold;
+
+    const cacheHit = await findCacheHit(
+      userId,
+      embedding,
+      effectiveCacheThreshold,
+      languageDetection.targetLanguage
+    );
+
+    if (cacheHit) {
+      const response: RagResponse = {
+        reason: "CACHE_HIT",
+        answer: cacheHit.answer,
+        citations: cacheHit.citations,
+        usage: undefined,
+        cached: true,
+        notice: cacheHit.notice,
+      };
+
+      const trailer: RagStreamTrailer = {
+        done: true,
+        citations: cacheHit.citations,
+      };
+
+      const events: string[] = [];
+      if (stream) {
+        events.push(toSseChunk({ delta: cacheHit.answer }));
+        events.push(toSseChunk(trailer));
+      }
+
+      await logTrace(
+        userId,
+        question,
+        languageDetection.targetLanguage,
+        "CACHE_HIT",
+        cacheHit.answer,
+        cacheHit.retrievedIds,
+        undefined,
+        sessionId
+      );
+
+      console.log(
+        JSON.stringify({
+          evt: "rag.query",
+          reason: "CACHE_HIT",
+          userId,
+          sessionId,
+          language: languageDetection.targetLanguage,
+          cached: true,
+          latencyMs: Date.now() - start,
+          topScores: [cacheHit.topScore],
+          retrievedIds: cacheHit.retrievedIds,
+        })
+      );
+
+      return {
+        response,
+        stream,
+        events,
+        trailer,
+        matches: [],
+        languageDetection,
+      };
+    }
+
+    const classification = classifyQuestion(
+      normalizedQuestion,
+      languageDetection.targetLanguage
+    );
+
+    if (!classification.isFitness) {
+      const message = classification.message || NOT_FITNESS_MESSAGES[languageDetection.targetLanguage];
+      const response: RagResponse = {
+        reason: "NOT_FITNESS",
+        answer: message,
+        citations: [],
+        cached: false,
+      };
+      const trailer: RagStreamTrailer = { done: true, citations: [] };
+      const events = stream ? [toSseChunk({ delta: message }), toSseChunk(trailer)] : [];
+
+      await logTrace(
+        userId,
+        question,
+        languageDetection.targetLanguage,
+        "NOT_FITNESS",
+        message,
+        [],
+        undefined,
+        sessionId
+      );
+
+      console.log(
+        JSON.stringify({
+          evt: "rag.query",
+          reason: "NOT_FITNESS",
+          userId,
+          sessionId,
+          language: languageDetection.targetLanguage,
+          cached: false,
+          latencyMs: Date.now() - start,
+          topScores: [],
+          retrievedIds: [],
+        })
+      );
+
+      return { response, stream, events, trailer, matches: [], languageDetection };
+    }
+
+    const effectiveTopK = typeof topK === "number" ? topK : RAG_CONSTANTS.defaultTopK;
+    const effectiveThreshold =
+      typeof threshold === "number" ? threshold : RAG_CONSTANTS.defaultThreshold;
+
+    const filter = buildMetadataFilter(userId, languageDetection.targetLanguage, metadata);
+
+    let matches = trimMatches(
+      await queryPinecone({
+        namespace: RAG_CONSTANTS.corpusNamespace,
+        topK: effectiveTopK,
+        vector: embedding,
+        filter,
+      })
+    );
+
+    const hasAboveThreshold = matches.some((match) => (match.score || 0) >= effectiveThreshold);
+
+    if (!hasAboveThreshold) {
+      matches = trimMatches(
+        await queryPinecone({
+          namespace: RAG_CONSTANTS.corpusNamespace,
+          topK: effectiveTopK,
+          vector: embedding,
+          filter: buildMetadataFilter(userId, "", metadata),
+        })
+      );
+    }
+
+    const filteredMatches = matches.filter((match) => (match.score || 0) >= effectiveThreshold);
+
+    if (!filteredMatches.length) {
+      const unknownAnswer =
+        languageDetection.targetLanguage === "he"
+          ? "אני לא יודע מההקשר שסופק."
+          : "I don't know from the provided context.";
+
+      const response: RagResponse = {
+        reason: "RETRIEVAL_EMPTY",
+        answer: unknownAnswer,
+        citations: [],
+        cached: false,
+      };
+      const trailer: RagStreamTrailer = { done: true, citations: [] };
+      const events = stream ? [toSseChunk({ delta: unknownAnswer }), toSseChunk(trailer)] : [];
+
+      await logTrace(
+        userId,
+        question,
+        languageDetection.targetLanguage,
+        "RETRIEVAL_EMPTY",
+        unknownAnswer,
+        [],
+        undefined,
+        sessionId
+      );
+
+      console.log(
+        JSON.stringify({
+          evt: "rag.query",
+          reason: "RETRIEVAL_EMPTY",
+          userId,
+          sessionId,
+          language: languageDetection.targetLanguage,
+          cached: false,
+          latencyMs: Date.now() - start,
+          topScores: matches.map((match) => match.score),
+          retrievedIds: [],
+        })
+      );
+
+      return { response, stream, events, trailer, matches: [], languageDetection };
+    }
+
+    const citations = buildCitations(filteredMatches);
+    const contextBlocks = buildContextBlocks(filteredMatches);
+
+    const deltas: string[] = [];
+    let finalAnswer = "";
+    let usage: UsageMetrics | undefined;
+
+    if (stream) {
+      if (languageDetection.needsFallbackNotice) {
+        deltas.push(toSseChunk({ delta: `${RAG_CONSTANTS.languageFallbackNotice}\n\n` }));
+      }
+      const result = await generateAnswer({
+        targetLanguage: languageDetection.targetLanguage,
+        contextBlocks,
+        question,
+        summary: undefined,
+        stream: true,
+        callbacks: {
+          onDelta: (delta) => {
+            if (!delta) return;
+            deltas.push(toSseChunk({ delta }));
+          },
+        },
+      });
+      finalAnswer = result.answer;
+      usage = result.usage;
+      if (languageDetection.needsFallbackNotice) {
+        finalAnswer = `${RAG_CONSTANTS.languageFallbackNotice}\n\n${finalAnswer}`;
+      }
+    } else {
+      const result = await generateAnswer({
+        targetLanguage: languageDetection.targetLanguage,
+        contextBlocks,
+        question,
+        summary: undefined,
+        stream: false,
+      });
+      finalAnswer = result.answer;
+      usage = result.usage;
+      if (languageDetection.needsFallbackNotice) {
+        finalAnswer = `${RAG_CONSTANTS.languageFallbackNotice}\n\n${finalAnswer}`;
+      }
+    }
+
+    if (!finalAnswer) {
+      finalAnswer =
+        languageDetection.targetLanguage === "he"
+          ? "לא הצלחתי להפיק תשובה מההקשר שסופק."
+          : "I was unable to generate an answer from the provided context.";
+    }
+
+    const response: RagResponse = {
+      reason: "ANSWER_GENERATED",
+      answer: finalAnswer,
+      citations,
+      usage,
+      cached: false,
+      notice: languageDetection.needsFallbackNotice
+        ? RAG_CONSTANTS.languageFallbackNotice
+        : undefined,
+    };
+
+    const trailer: RagStreamTrailer = {
+      done: true,
+      citations,
+      usage,
+    };
+
+    const events = stream ? [...deltas, toSseChunk(trailer)] : [];
+
+    const retrievedIds = citations.map((citation) => citation.sourceId);
+
+    const cacheDoc: IRagCacheEntry = {
+      userId,
+      question,
+      normalizedQuestion,
+      answer: finalAnswer,
+      language: languageDetection.targetLanguage,
+      citations,
+      retrievedIds,
+      topScore: filteredMatches[0]?.score || 0,
+      embedding,
+      refusal: false,
+      notice: languageDetection.needsFallbackNotice
+        ? RAG_CONSTANTS.languageFallbackNotice
+        : undefined,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    const lowerAnswer = finalAnswer.toLowerCase();
+    if (
+      citations.length > 0 &&
+      finalAnswer &&
+      !finalAnswer.includes("אני לא יודע") &&
+      !lowerAnswer.includes("i don't know")
+    ) {
+      await storeCacheHit(cacheDoc, embedding, userId);
+    }
+
+    await logTrace(
+      userId,
+      question,
+      languageDetection.targetLanguage,
+      "ANSWER_GENERATED",
+      finalAnswer,
+      retrievedIds,
+      usage,
+      sessionId
+    );
+
+    console.log(
+      JSON.stringify({
+        evt: "rag.query",
+        reason: "ANSWER_GENERATED",
+        userId,
+        sessionId,
+        language: languageDetection.targetLanguage,
+        cached: false,
+        latencyMs: Date.now() - start,
+        topK: effectiveTopK,
+        threshold: effectiveThreshold,
+        retrievedIds,
+        topScores: filteredMatches.map((match) => match.score),
+        usage,
+      })
+    );
+
+    return {
+      response,
+      stream,
+      events,
+      trailer,
+      matches: filteredMatches,
+      languageDetection,
+    };
+  }
+
+  async ingest(request: RagIngestRequest) {
+    const { userId, sourceId, chunks, visibility = "private", lang = "en" } = request;
+    if (!userId || !sourceId) {
+      throw { status: StatusCode.BAD_REQUEST, message: "userId and sourceId are required" };
+    }
+    if (!Array.isArray(chunks) || chunks.length === 0) {
+      throw { status: StatusCode.BAD_REQUEST, message: "chunks are required" };
+    }
+
+    const prepared = await Promise.all(
+      chunks.map(async (chunk) => {
+        const text = normalizeText(chunk.text || "");
+        if (!text) return null;
+        const hash = computeHash(text);
+        const existing = await sourceRepository.findByHash(userId, hash);
+        if (existing) {
+          return null;
+        }
+        const embedding = await createEmbedding(text);
+        const chunkId = chunk.id || computeHash(`${hash}-${Date.now()}`);
+        return {
+          text,
+          hash,
+          embedding,
+          chunkId,
+          metadata: chunk.metadata || {},
+        };
+      })
+    );
+
+    const filtered = prepared.filter((item): item is NonNullable<typeof item> => Boolean(item));
+
+    if (!filtered.length) {
+      return { inserted: 0 };
+    }
+
+    await Promise.all(
+      filtered.map((item) =>
+        sourceRepository.upsertChunk({
+          userId,
+          sourceId,
+          chunkId: item.chunkId,
+          text: item.text,
+          hash: item.hash,
+          metadata: item.metadata,
+          lang,
+          visibility,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        } as any)
+      )
+    );
+
+    await upsertVectors(
+      RAG_CONSTANTS.corpusNamespace,
+      filtered.map((item) => ({
+        id: `${userId}-${sourceId}-${item.chunkId}`,
+        values: item.embedding,
+        metadata: {
+          userId,
+          sourceId,
+          lang,
+          visibility,
+          text: item.text,
+          page: item.metadata?.page,
+          tags: item.metadata?.tags,
+          hash: item.hash,
+        },
+      }))
+    );
+
+    return { inserted: filtered.length };
+  }
+}

--- a/server/src/rag/config.ts
+++ b/server/src/rag/config.ts
@@ -1,0 +1,30 @@
+const parsePositiveNumber = (value: string | undefined, fallback: number): number => {
+  if (!value) return fallback;
+  const parsed = Number(value);
+  if (Number.isFinite(parsed) && parsed > 0) {
+    return parsed;
+  }
+  return fallback;
+};
+
+export const RAG_CONSTANTS = {
+  cacheNamespace: "semantic-cache",
+  corpusNamespace: "corpus",
+  defaultTopK: parsePositiveNumber(process.env.RAG_RETRIEVAL_TOP_K, 5),
+  defaultThreshold: Number.isFinite(Number(process.env.RAG_RETRIEVAL_THRESHOLD))
+    ? Number(process.env.RAG_RETRIEVAL_THRESHOLD)
+    : 0.5,
+  defaultCacheThreshold: Number.isFinite(Number(process.env.RAG_CACHE_THRESHOLD))
+    ? Number(process.env.RAG_CACHE_THRESHOLD)
+    : 0.9,
+  maxContextChunks: 6,
+  minContextSentences: 2,
+  languageFallbackNotice:
+    "השאלה זוהתה בשפה שאינה נתמכת, התשובה מסופקת בעברית בהתאם למדיניות.",
+  rateLimitWindowMs: parsePositiveNumber(process.env.RAG_RATE_LIMIT_WINDOW_MS, 60_000),
+  rateLimitMaxRequests: parsePositiveNumber(process.env.RAG_RATE_LIMIT_MAX_REQUESTS, 8),
+  chatModel: process.env.OPENAI_CHAT_MODEL || "gpt-4o-mini",
+  embeddingModel: process.env.OPENAI_EMBEDDING_MODEL || "text-embedding-3-small",
+};
+
+export const getPineconeIndexName = () => process.env.PINECONE_INDEX || "diet-questions";

--- a/server/src/rag/config.ts
+++ b/server/src/rag/config.ts
@@ -19,8 +19,7 @@ export const RAG_CONSTANTS = {
     : 0.9,
   maxContextChunks: 6,
   minContextSentences: 2,
-  languageFallbackNotice:
-    "השאלה זוהתה בשפה שאינה נתמכת, התשובה מסופקת בעברית בהתאם למדיניות.",
+  languageFallbackNotice: "השאלה זוהתה בשפה שאינה נתמכת, התשובה מסופקת בעברית בהתאם למדיניות.",
   rateLimitWindowMs: parsePositiveNumber(process.env.RAG_RATE_LIMIT_WINDOW_MS, 60_000),
   rateLimitMaxRequests: parsePositiveNumber(process.env.RAG_RATE_LIMIT_MAX_REQUESTS, 8),
   chatModel: process.env.OPENAI_CHAT_MODEL || "gpt-4o-mini",

--- a/server/src/rag/db.ts
+++ b/server/src/rag/db.ts
@@ -1,0 +1,14 @@
+import { RagCacheRepository } from "../repositories/Rag/RagCacheRepository";
+import { RagTraceRepository } from "../repositories/Rag/RagTraceRepository";
+import { RagRateLimitRepository } from "../repositories/Rag/RagRateLimitRepository";
+import { RagSourceRepository } from "../repositories/Rag/RagSourceRepository";
+
+const ragCacheRepository = new RagCacheRepository();
+const ragTraceRepository = new RagTraceRepository();
+const ragRateLimitRepository = new RagRateLimitRepository();
+const ragSourceRepository = new RagSourceRepository();
+
+export const getRagCacheRepository = () => ragCacheRepository;
+export const getRagTraceRepository = () => ragTraceRepository;
+export const getRagRateLimitRepository = () => ragRateLimitRepository;
+export const getRagSourceRepository = () => ragSourceRepository;

--- a/server/src/rag/dietQuestionClassifier.ts
+++ b/server/src/rag/dietQuestionClassifier.ts
@@ -96,19 +96,37 @@ export const classifyQuestion = (
   const text = normalizeText(question).toLowerCase();
 
   if (!text) {
-    return { isFitness: false, reason: "NOT_FITNESS", message: NOT_FITNESS_MESSAGES[targetLanguage] };
+    return {
+      isFitness: false,
+      reason: "NOT_FITNESS",
+      message: NOT_FITNESS_MESSAGES[targetLanguage],
+    };
   }
 
   if (containsKeyword(text, NON_FITNESS_KEYWORDS)) {
-    return { isFitness: false, reason: "NOT_FITNESS", message: NOT_FITNESS_MESSAGES[targetLanguage] };
+    return {
+      isFitness: false,
+      reason: "NOT_FITNESS",
+      message: NOT_FITNESS_MESSAGES[targetLanguage],
+    };
   }
 
   const isFitnessRelated =
-    containsKeyword(text, FITNESS_KEYWORDS_EN.map((k) => k.toLowerCase())) ||
-    containsKeyword(text, FITNESS_KEYWORDS_HE.map((k) => k.toLowerCase()));
+    containsKeyword(
+      text,
+      FITNESS_KEYWORDS_EN.map((k) => k.toLowerCase())
+    ) ||
+    containsKeyword(
+      text,
+      FITNESS_KEYWORDS_HE.map((k) => k.toLowerCase())
+    );
 
   if (!isFitnessRelated) {
-    return { isFitness: false, reason: "NOT_FITNESS", message: NOT_FITNESS_MESSAGES[targetLanguage] };
+    return {
+      isFitness: false,
+      reason: "NOT_FITNESS",
+      message: NOT_FITNESS_MESSAGES[targetLanguage],
+    };
   }
 
   return { isFitness: true, reason: "FITNESS" };

--- a/server/src/rag/dietQuestionClassifier.ts
+++ b/server/src/rag/dietQuestionClassifier.ts
@@ -1,0 +1,115 @@
+import { SupportedLanguage } from "./language";
+import { normalizeText } from "./text";
+
+const FITNESS_KEYWORDS_EN = [
+  "diet",
+  "nutrition",
+  "protein",
+  "calorie",
+  "training",
+  "workout",
+  "exercise",
+  "cardio",
+  "strength",
+  "mobility",
+  "stretch",
+  "recovery",
+  "sleep",
+  "hydration",
+  "meal",
+  "macro",
+  "weight",
+  "fat loss",
+  "muscle",
+  "fitness",
+  "wellness",
+  "health",
+  "habit",
+  "supplement",
+  "injury prevention",
+  "warm up",
+  "cool down",
+];
+
+const FITNESS_KEYWORDS_HE = [
+  "תזונה",
+  "תכנית",
+  "תוכנית",
+  "אימון",
+  "אימונים",
+  "כושר",
+  "בריאות",
+  "חיזוק",
+  "חלבון",
+  "פחמימות",
+  "שומן",
+  "קלוריות",
+  "ירידה במשקל",
+  "עלייה במסת שריר",
+  "גמישות",
+  "יציבה",
+  "שינה",
+  "התאוששות",
+  "מתיחות",
+  "ארוחות",
+  "תוספי",
+  "תוספים",
+  "מאזן אנרגיה",
+  "הרגלים",
+  "לב",
+  "סיבולת",
+];
+
+const NON_FITNESS_KEYWORDS = [
+  "investment",
+  "stock",
+  "crypto",
+  "software",
+  "programming",
+  "finance",
+  "marketing",
+  "sales",
+  "legal",
+  "tax",
+  "פיננס",
+  "משפט",
+];
+
+export const NOT_FITNESS_MESSAGES: Record<SupportedLanguage, string> = {
+  he: "ניתן לשאול רק שאלות בתחום הכושר, התזונה והבריאות הכללית.",
+  en: "Please ask about fitness, nutrition, or general wellness topics only.",
+};
+
+export type ClassificationResult = {
+  isFitness: boolean;
+  reason: "FITNESS" | "NOT_FITNESS";
+  message?: string;
+};
+
+const containsKeyword = (text: string, keywords: string[]) =>
+  keywords.some((keyword) => text.includes(keyword));
+
+export const classifyQuestion = (
+  question: string,
+  targetLanguage: SupportedLanguage
+): ClassificationResult => {
+  const text = normalizeText(question).toLowerCase();
+
+  if (!text) {
+    return { isFitness: false, reason: "NOT_FITNESS", message: NOT_FITNESS_MESSAGES[targetLanguage] };
+  }
+
+  if (containsKeyword(text, NON_FITNESS_KEYWORDS)) {
+    return { isFitness: false, reason: "NOT_FITNESS", message: NOT_FITNESS_MESSAGES[targetLanguage] };
+  }
+
+  const isFitnessRelated =
+    containsKeyword(text, FITNESS_KEYWORDS_EN.map((k) => k.toLowerCase())) ||
+    containsKeyword(text, FITNESS_KEYWORDS_HE.map((k) => k.toLowerCase()));
+
+  if (!isFitnessRelated) {
+    return { isFitness: false, reason: "NOT_FITNESS", message: NOT_FITNESS_MESSAGES[targetLanguage] };
+  }
+
+  return { isFitness: true, reason: "FITNESS" };
+};

--- a/server/src/rag/index.ts
+++ b/server/src/rag/index.ts
@@ -1,0 +1,3 @@
+import { RagAnswerService } from "./answer.service";
+
+export const ragAnswerService = new RagAnswerService();

--- a/server/src/rag/language.ts
+++ b/server/src/rag/language.ts
@@ -1,0 +1,31 @@
+export type SupportedLanguage = "he" | "en";
+
+const HEBREW_REGEX = /[\u0590-\u05FF]/;
+const ENGLISH_REGEX = /[A-Za-z]/;
+const LETTER_REGEX = /\p{L}/u;
+
+export type LanguageDetection = {
+  inputLanguage: SupportedLanguage | "other";
+  targetLanguage: SupportedLanguage;
+  needsFallbackNotice: boolean;
+};
+
+export const detectLanguage = (text: string): LanguageDetection => {
+  const cleaned = text.replace(/\s+/g, " ").trim();
+  const hasLetters = LETTER_REGEX.test(cleaned);
+
+  let detected: SupportedLanguage | "other" = "other";
+
+  if (HEBREW_REGEX.test(cleaned)) {
+    detected = "he";
+  } else if (hasLetters && ENGLISH_REGEX.test(cleaned)) {
+    detected = "en";
+  } else if (!hasLetters) {
+    detected = "en"; // default to en when no letters (e.g., numbers only)
+  }
+
+  const targetLanguage: SupportedLanguage = detected === "he" ? "he" : detected === "en" ? "en" : "he";
+  const needsFallbackNotice = detected === "other";
+
+  return { inputLanguage: detected, targetLanguage, needsFallbackNotice };
+};

--- a/server/src/rag/language.ts
+++ b/server/src/rag/language.ts
@@ -24,7 +24,8 @@ export const detectLanguage = (text: string): LanguageDetection => {
     detected = "en"; // default to en when no letters (e.g., numbers only)
   }
 
-  const targetLanguage: SupportedLanguage = detected === "he" ? "he" : detected === "en" ? "en" : "he";
+  const targetLanguage: SupportedLanguage =
+    detected === "he" ? "he" : detected === "en" ? "en" : "he";
   const needsFallbackNotice = detected === "other";
 
   return { inputLanguage: detected, targetLanguage, needsFallbackNotice };

--- a/server/src/rag/openai.ts
+++ b/server/src/rag/openai.ts
@@ -1,0 +1,160 @@
+import OpenAI from "openai";
+import { SYSTEM_PROMPT } from "./prompts";
+import { normalizeText } from "./text";
+import { RAG_CONSTANTS } from "./config";
+
+let cachedClient: OpenAI | null = null;
+
+const getClient = () => {
+  if (cachedClient) {
+    return cachedClient;
+  }
+
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    throw new Error("Missing OPENAI_API_KEY");
+  }
+
+  cachedClient = new OpenAI({ apiKey });
+  return cachedClient;
+};
+
+export type UsageMetrics = {
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+};
+
+export type StreamCallbacks = {
+  onDelta?: (delta: string) => void;
+};
+
+export type GenerateAnswerParams = {
+  targetLanguage: string;
+  contextBlocks: string[];
+  question: string;
+  summary?: string;
+  stream?: boolean;
+  callbacks?: StreamCallbacks;
+};
+
+export type GenerateAnswerResult = {
+  answer: string;
+  usage?: UsageMetrics;
+};
+
+const buildSystemPrompt = (targetLanguage: string) =>
+  SYSTEM_PROMPT.replace(/<targetLang>/g, targetLanguage);
+
+const buildPrompt = (params: GenerateAnswerParams): string => {
+  const { contextBlocks, question, summary } = params;
+  const promptParts: string[] = [];
+
+  if (summary) {
+    promptParts.push(`Conversation summary: ${summary}`);
+  }
+
+  if (contextBlocks.length > 0) {
+    promptParts.push(
+      contextBlocks
+        .map((block, index) => `Context [${index + 1}]: ${normalizeText(block)}`)
+        .join("\n")
+    );
+  }
+
+  promptParts.push(`Question: ${normalizeText(question)}`);
+
+  return promptParts.join("\n\n");
+};
+
+export const generateAnswer = async (
+  params: GenerateAnswerParams
+): Promise<GenerateAnswerResult> => {
+  const { stream, callbacks, targetLanguage } = params;
+  const systemPrompt = buildSystemPrompt(targetLanguage);
+  const prompt = buildPrompt(params);
+
+  const client = getClient();
+
+  if (stream) {
+    try {
+      const streamResponse = await client.chat.completions.create({
+        model: RAG_CONSTANTS.chatModel,
+        messages: [
+          { role: "system", content: systemPrompt },
+          { role: "user", content: prompt },
+        ],
+        temperature: 0.2,
+        stream: true,
+        stream_options: { include_usage: true },
+      });
+
+      let answer = "";
+      let usage: UsageMetrics | undefined;
+
+      for await (const part of streamResponse) {
+        const delta = part.choices?.[0]?.delta?.content || "";
+        if (delta) {
+          answer += delta;
+          callbacks?.onDelta?.(delta);
+        }
+
+        const chunkUsage = part.usage;
+        if (chunkUsage) {
+          usage = {
+            promptTokens: chunkUsage.prompt_tokens,
+            completionTokens: chunkUsage.completion_tokens,
+            totalTokens: chunkUsage.total_tokens,
+          };
+        }
+      }
+
+      return { answer: answer.trim(), usage };
+    } catch (error: any) {
+      throw new Error(`OpenAI error: ${error?.message || error}`);
+    }
+  }
+
+  try {
+    const response = await client.chat.completions.create({
+      model: RAG_CONSTANTS.chatModel,
+      messages: [
+        { role: "system", content: systemPrompt },
+        { role: "user", content: prompt },
+      ],
+      temperature: 0.2,
+    });
+
+    const answer = response.choices?.[0]?.message?.content?.trim?.() || "";
+    const usage: UsageMetrics | undefined = response.usage
+      ? {
+          promptTokens: response.usage.prompt_tokens,
+          completionTokens: response.usage.completion_tokens,
+          totalTokens: response.usage.total_tokens,
+        }
+      : undefined;
+
+    return { answer, usage };
+  } catch (error: any) {
+    throw new Error(`OpenAI error: ${error?.message || error}`);
+  }
+};
+
+export const createEmbedding = async (text: string): Promise<number[]> => {
+  const client = getClient();
+  try {
+    const response = await client.embeddings.create({
+      model: RAG_CONSTANTS.embeddingModel,
+      input: normalizeText(text),
+    });
+
+    const embedding = response.data?.[0]?.embedding as number[] | undefined;
+    if (!embedding) {
+      throw new Error("Embedding not returned by OpenAI");
+    }
+
+    return embedding;
+  } catch (error: any) {
+    throw new Error(`OpenAI embedding error: ${error?.message || error}`);
+  }
+};

--- a/server/src/rag/pinecone.ts
+++ b/server/src/rag/pinecone.ts
@@ -43,9 +43,7 @@ export type UpsertVector = {
   metadata?: Record<string, any>;
 };
 
-export const queryPinecone = async (
-  options: QueryOptions
-): Promise<PineconeMatch[]> => {
+export const queryPinecone = async (options: QueryOptions): Promise<PineconeMatch[]> => {
   const index = getIndex();
   const namespace = index.namespace(options.namespace);
   const response = await namespace.query({
@@ -58,10 +56,7 @@ export const queryPinecone = async (
   return (response.matches as PineconeMatch[]) || [];
 };
 
-export const upsertVectors = async (
-  namespace: string,
-  vectors: UpsertVector[]
-) => {
+export const upsertVectors = async (namespace: string, vectors: UpsertVector[]) => {
   if (!vectors.length) {
     return;
   }

--- a/server/src/rag/pinecone.ts
+++ b/server/src/rag/pinecone.ts
@@ -1,0 +1,123 @@
+import { Pinecone } from "@pinecone-database/pinecone";
+import { getPineconeIndexName, RAG_CONSTANTS } from "./config";
+
+let cachedClient: Pinecone | null = null;
+
+const getClient = () => {
+  if (cachedClient) {
+    return cachedClient;
+  }
+
+  const apiKey = process.env.PINECONE_API_KEY;
+  if (!apiKey) {
+    throw new Error("Missing PINECONE_API_KEY");
+  }
+
+  cachedClient = new Pinecone({ apiKey });
+  return cachedClient;
+};
+
+const getIndex = () => {
+  const client = getClient();
+  const indexName = getPineconeIndexName();
+  return client.index(indexName);
+};
+
+export type PineconeMatch = {
+  id: string;
+  score: number;
+  metadata?: Record<string, any>;
+  values?: number[];
+};
+
+export type QueryOptions = {
+  namespace: string;
+  vector: number[];
+  topK: number;
+  filter?: Record<string, any>;
+};
+
+export type UpsertVector = {
+  id: string;
+  values: number[];
+  metadata?: Record<string, any>;
+};
+
+export const queryPinecone = async (
+  options: QueryOptions
+): Promise<PineconeMatch[]> => {
+  const index = getIndex();
+  const namespace = index.namespace(options.namespace);
+  const response = await namespace.query({
+    topK: options.topK,
+    vector: options.vector,
+    filter: options.filter,
+    includeMetadata: true,
+  });
+
+  return (response.matches as PineconeMatch[]) || [];
+};
+
+export const upsertVectors = async (
+  namespace: string,
+  vectors: UpsertVector[]
+) => {
+  if (!vectors.length) {
+    return;
+  }
+
+  const index = getIndex();
+  const namespaceClient = index.namespace(namespace);
+  const payload = vectors.map((vector) => ({
+    id: vector.id,
+    values: vector.values,
+    metadata: vector.metadata,
+  }));
+
+  await namespaceClient.upsert(payload);
+};
+
+export const deleteVectors = async (namespace: string, ids: string[]) => {
+  if (!ids.length) {
+    return;
+  }
+
+  const index = getIndex();
+  const namespaceClient = index.namespace(namespace);
+  const deleteMany = (namespaceClient as any).deleteMany as
+    | ((ids: string[]) => Promise<void>)
+    | undefined;
+
+  if (deleteMany) {
+    await deleteMany(ids);
+    return;
+  }
+
+  await namespaceClient.delete({ ids });
+};
+
+export const buildMetadataFilter = (
+  userId: string,
+  language: string,
+  additionalFilter?: Record<string, any>
+) => {
+  const baseFilter: Record<string, any> = {
+    userId,
+  };
+
+  if (language) {
+    baseFilter.lang = language;
+  }
+
+  if (additionalFilter && Object.keys(additionalFilter).length > 0) {
+    Object.assign(baseFilter, additionalFilter);
+  }
+
+  return baseFilter;
+};
+
+export const trimMatches = (matches: PineconeMatch[]) =>
+  matches
+    .filter((match) => typeof match.score === "number")
+    .sort((a, b) => (b.score || 0) - (a.score || 0))
+    .slice(0, RAG_CONSTANTS.maxContextChunks);

--- a/server/src/rag/prompts.ts
+++ b/server/src/rag/prompts.ts
@@ -1,0 +1,6 @@
+export const SYSTEM_PROMPT = [
+  "General fitness and wellness guidance only; never diagnose or give medical directives—advise consulting a professional for injuries, conditions, or symptoms.",
+  "Use ONLY the provided context; if the context lacks an answer, respond that you don't know.",
+  "Respond in <targetLang>; when context sources mix languages, summarise them into <targetLang>.",
+  "Cite sources as [^i] in order, including source ids or URLs when present."
+].join(" ");

--- a/server/src/rag/prompts.ts
+++ b/server/src/rag/prompts.ts
@@ -2,5 +2,5 @@ export const SYSTEM_PROMPT = [
   "General fitness and wellness guidance only; never diagnose or give medical directives—advise consulting a professional for injuries, conditions, or symptoms.",
   "Use ONLY the provided context; if the context lacks an answer, respond that you don't know.",
   "Respond in <targetLang>; when context sources mix languages, summarise them into <targetLang>.",
-  "Cite sources as [^i] in order, including source ids or URLs when present."
+  "Cite sources as [^i] in order, including source ids or URLs when present.",
 ].join(" ");

--- a/server/src/rag/text.ts
+++ b/server/src/rag/text.ts
@@ -1,0 +1,13 @@
+export const normalizeText = (text: string): string => text.replace(/\s+/g, " ").trim();
+
+export const summariseSentences = (text: string, maxSentences: number): string => {
+  const clean = normalizeText(text);
+  if (!maxSentences || maxSentences <= 0) return clean;
+
+  const sentences = clean.split(/(?<=[.!?])\s+/);
+  if (sentences.length <= maxSentences) {
+    return clean;
+  }
+
+  return sentences.slice(0, maxSentences).join(" ");
+};

--- a/server/src/rag/types.ts
+++ b/server/src/rag/types.ts
@@ -1,0 +1,53 @@
+import { IRagCitation } from "../models/ragCacheModel";
+import { UsageMetrics } from "./openai";
+import { SupportedLanguage } from "./language";
+
+export type RagReason =
+  | "CACHE_HIT"
+  | "CACHE_MISS"
+  | "CACHE_STORED"
+  | "NOT_FITNESS"
+  | "RETRIEVAL_EMPTY"
+  | "ANSWER_GENERATED";
+
+export type RagRequest = {
+  userId: string;
+  question: string;
+  sessionId?: string;
+  stream?: boolean;
+  topK?: number;
+  threshold?: number;
+  cacheThreshold?: number;
+  metadata?: Record<string, any>;
+};
+
+export type RagIngestChunk = {
+  id: string;
+  text: string;
+  metadata?: Record<string, any>;
+};
+
+export type RagIngestRequest = {
+  userId: string;
+  sourceId: string;
+  visibility?: "private" | "shared";
+  lang?: SupportedLanguage;
+  chunks: RagIngestChunk[];
+};
+
+export type Citation = IRagCitation;
+
+export type RagResponse = {
+  reason: RagReason;
+  answer: string;
+  citations: Citation[];
+  usage?: UsageMetrics;
+  cached?: boolean;
+  notice?: string;
+};
+
+export type RagStreamTrailer = {
+  done: boolean;
+  citations: Citation[];
+  usage?: UsageMetrics;
+};

--- a/server/src/repositories/Rag/RagCacheRepository.ts
+++ b/server/src/repositories/Rag/RagCacheRepository.ts
@@ -31,11 +31,7 @@ export class RagCacheRepository extends BaseRepository<IRagCacheEntry> {
   upsertCacheEntry = async (doc: IRagCacheEntry) => {
     const { userId, normalizedQuestion } = doc;
     return await this.model
-      .findOneAndUpdate(
-        { userId, normalizedQuestion },
-        { $set: doc },
-        { upsert: true, new: true }
-      )
+      .findOneAndUpdate({ userId, normalizedQuestion }, { $set: doc }, { upsert: true, new: true })
       .lean();
   };
 

--- a/server/src/repositories/Rag/RagCacheRepository.ts
+++ b/server/src/repositories/Rag/RagCacheRepository.ts
@@ -1,0 +1,45 @@
+import { FilterQuery } from "mongoose";
+import RagCacheModel, { IRagCacheEntry } from "../../models/ragCacheModel";
+import { BaseRepository } from "../BaseRepository";
+
+export class RagCacheRepository extends BaseRepository<IRagCacheEntry> {
+  constructor() {
+    super(RagCacheModel);
+  }
+
+  findByNormalizedQuestion = async (
+    userId: string,
+    normalizedQuestion: string
+  ): Promise<IRagCacheEntry | null> => {
+    try {
+      return await this.model
+        .findOne({ userId, normalizedQuestion } as FilterQuery<IRagCacheEntry>)
+        .lean();
+    } catch (error) {
+      return null;
+    }
+  };
+
+  findByIdLean = async (id: string) => {
+    try {
+      return await this.model.findById(id).lean();
+    } catch (error) {
+      return null;
+    }
+  };
+
+  upsertCacheEntry = async (doc: IRagCacheEntry) => {
+    const { userId, normalizedQuestion } = doc;
+    return await this.model
+      .findOneAndUpdate(
+        { userId, normalizedQuestion },
+        { $set: doc },
+        { upsert: true, new: true }
+      )
+      .lean();
+  };
+
+  listRecent = async (userId: string, limit: number = 20) => {
+    return await this.model.find({ userId }).sort({ updatedAt: -1 }).limit(limit).lean();
+  };
+}

--- a/server/src/repositories/Rag/RagRateLimitRepository.ts
+++ b/server/src/repositories/Rag/RagRateLimitRepository.ts
@@ -1,0 +1,8 @@
+import RagRateLimitModel, { IRagRateLimit } from "../../models/ragRateLimitModel";
+import { BaseRepository } from "../BaseRepository";
+
+export class RagRateLimitRepository extends BaseRepository<IRagRateLimit> {
+  constructor() {
+    super(RagRateLimitModel);
+  }
+}

--- a/server/src/repositories/Rag/RagSourceRepository.ts
+++ b/server/src/repositories/Rag/RagSourceRepository.ts
@@ -13,11 +13,7 @@ export class RagSourceRepository extends BaseRepository<IRagSourceChunk> {
   async upsertChunk(doc: IRagSourceChunk) {
     const { userId, sourceId, chunkId } = doc;
     return await this.model
-      .findOneAndUpdate(
-        { userId, sourceId, chunkId },
-        { $set: doc },
-        { upsert: true, new: true }
-      )
+      .findOneAndUpdate({ userId, sourceId, chunkId }, { $set: doc }, { upsert: true, new: true })
       .lean();
   }
 }

--- a/server/src/repositories/Rag/RagSourceRepository.ts
+++ b/server/src/repositories/Rag/RagSourceRepository.ts
@@ -1,0 +1,23 @@
+import RagSourceModel, { IRagSourceChunk } from "../../models/ragSourceModel";
+import { BaseRepository } from "../BaseRepository";
+
+export class RagSourceRepository extends BaseRepository<IRagSourceChunk> {
+  constructor() {
+    super(RagSourceModel);
+  }
+
+  async findByHash(userId: string, hash: string) {
+    return await this.model.findOne({ userId, hash }).lean();
+  }
+
+  async upsertChunk(doc: IRagSourceChunk) {
+    const { userId, sourceId, chunkId } = doc;
+    return await this.model
+      .findOneAndUpdate(
+        { userId, sourceId, chunkId },
+        { $set: doc },
+        { upsert: true, new: true }
+      )
+      .lean();
+  }
+}

--- a/server/src/repositories/Rag/RagTraceRepository.ts
+++ b/server/src/repositories/Rag/RagTraceRepository.ts
@@ -1,0 +1,8 @@
+import RagTraceModel, { IRagTrace } from "../../models/ragTraceModel";
+import { BaseRepository } from "../BaseRepository";
+
+export class RagTraceRepository extends BaseRepository<IRagTrace> {
+  constructor() {
+    super(RagTraceModel);
+  }
+}


### PR DESCRIPTION
## Summary
- document frontend integration patterns for the Lambda RAG chatbot, including payloads, streaming flow, and UX guidance
- ensure SSE streaming responses explicitly close the connection once the final chunk has been sent
- refactor the RAG OpenAI and Pinecone adapters to use the official SDKs while preserving prompts, caching, and telemetry

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f0e271b0dc832bb2f9d2e3b421b0cb