### PR TITLE
Add cheap OpenAI fitness intent fallback

### DIFF
--- a/server/docs/rag-chatbot.md
+++ b/server/docs/rag-chatbot.md
@@ -7,6 +7,9 @@
 - **src/rag/pinecone.ts** — Minimal Pinecone REST helper that resolves the index host dynamically and exposes query/upsert/delete helpers plus metadata filters.
 - **src/rag/answer.service.ts** — Main orchestration for rate limiting, semantic cache reuse, Pinecone retrieval, OpenAI generation, cache persistence, logging, and MongoDB traces.
 - **src/rag/dietQuestionClassifier.ts** — Keyword-based fitness/health classifier that preserves the previous diet-only control flow semantics.
+- **src/rag/binaryClassifier.ts** — Cheap heuristic binary classifier with an OpenAI yes/no fallback used as a secondary fitness gate when the primary classifier rejects a prompt.
+- **src/rag/denylist.ts** — High-risk topic guard that blocks politics, extremism, hate, NSFW, and other disallowed themes before any retrieval.
+- **src/rag/greetings.ts** — Lightweight greeting detector used to short-circuit friendly salutations without invoking OpenAI.
 - **src/rag/language.ts** — HE/EN detector with fallback notice handling.
 - **src/rag/db.ts** — Singleton repository accessors for cache, traces, sources, and rate-limit documents.
 - **src/rag/index.ts** — Exports a shared `RagAnswerService` instance.
@@ -32,23 +35,25 @@
 
 1. Rate limit enforcement per user (Mongo sliding window).
 2. Language detection (HE/EN/other → HE) and fallback notice setup.
-3. Semantic cache lookup (Pinecone namespace `semantic-cache` + Mongo document) with 0.9 default threshold.
-4. Fitness/health classifier gate with localized rejection message when irrelevant.
-5. Pinecone retrieval (`corpus` namespace) with lang-preferring filter, threshold fallback, and trimmed context sentences.
-6. OpenAI generation at temperature 0.2 with streaming support, citations, and fallback message when no context meets threshold.
-7. Cache persistence (Mongo + Pinecone) for successful, cited answers and trace logging for observability.
-8. Structured console log `evt: "rag.query"` summarizing latency, tokens, retrieved IDs, and reason code.
+3. Greeting short-circuit: simple salutations return `reason: "GREETING"` with no model calls.
+4. High-risk topic denylist (politics, extremism, hate, NSFW, etc.) with localized refusal and optional cache stub.
+5. Semantic cache lookup (Pinecone namespace `semantic-cache` + Mongo document) with 0.88 default threshold, stale-vector cleanup, and refusal stub reuse.
+6. Fitness/health classifier gate with localized rejection message when irrelevant, backed by a binary heuristic override.
+7. Pinecone retrieval (`corpus` namespace) with lang-preferring filter, threshold fallback, and trimmed context sentences.
+8. OpenAI generation at temperature 0.2 with streaming support, citations, and a safety fallback prompt when no context is retrieved.
+9. Cache persistence (Mongo + Pinecone) for successful answers and refusal stubs plus trace logging for observability.
+10. Structured console log `evt: "rag.query"` summarizing latency, tokens, retrieved IDs, and reason code alongside branch-specific events (cache miss, stale cache, blocked topics, binary classifier).
 
 ## Tuning Knobs
 
-- Environment-driven: `RAG_RETRIEVAL_TOP_K`, `RAG_RETRIEVAL_THRESHOLD`, `RAG_CACHE_THRESHOLD`, `RAG_RATE_LIMIT_WINDOW_MS`, `RAG_RATE_LIMIT_MAX_REQUESTS`, `OPENAI_CHAT_MODEL`, `OPENAI_EMBEDDING_MODEL` (all optional).
+- Environment-driven: `RAG_RETRIEVAL_TOP_K`, `RAG_RETRIEVAL_THRESHOLD`, `RAG_CACHE_THRESHOLD` (default 0.88), `RAG_RATE_LIMIT_WINDOW_MS`, `RAG_RATE_LIMIT_MAX_REQUESTS`, `OPENAI_CHAT_MODEL`, `OPENAI_EMBEDDING_MODEL`, `OPENAI_EMBEDDING_DIMENSIONS` (default 512), `RAG_ALLOW_FALLBACK_LLM`, `RAG_DENYLIST_ENABLED`, `RAG_BINARY_CLASSIFIER_ENABLED`, `RAG_CACHE_REFUSAL_STUBS`, `RAG_BINARY_CLASSIFIER_MODEL`, `RAG_BINARY_CLASSIFIER_MAX_TOKENS`.
 - Request-level: `topK`, `threshold`, `cacheThreshold`, `stream`, and metadata filters.
 - Pinecone namespaces: `semantic-cache` (cache) and `corpus` (canonical content).
 
 ## Operational Notes
 
 - Streaming responses emit `data: {"delta"}` chunks followed by a trailer `data: {"done":true,...}`.
-- Non-streaming responses return `{ reason, answer, citations, usage, cached, notice, language }`.
+- Non-streaming responses return `{ reason, answer, citations, usage, cached, notice, refusal, greeting, language }`.
 - Ingestion requires an `adminUserId` belonging to an admin user.
 - Rate limit exceedance returns HTTP 429 with `{ message: "rate limit exceeded" }`.
 - Language fallback notice: `השאלה זוהתה בשפה שאינה נתמכת, התשובה מסופקת בעברית בהתאם למדיניות.` prefixed to answers when input is neither HE nor EN.

--- a/server/src/controllers/ragController.ts
+++ b/server/src/controllers/ragController.ts
@@ -58,6 +58,8 @@ export class RagController {
         usage: result.response.usage,
         cached: result.response.cached,
         notice: result.response.notice,
+        refusal: result.response.refusal,
+        greeting: result.response.greeting,
         language: result.languageDetection.targetLanguage,
       };
 

--- a/server/src/functions/rag/index.ts
+++ b/server/src/functions/rag/index.ts
@@ -2,6 +2,21 @@ import { APIGatewayProxyEvent, APIGatewayProxyResult, Context } from "aws-lambda
 import { handleApiCall } from "../baseHandler";
 import { RagController } from "../../controllers/ragController";
 
+type LambdaWarmerEvent = {
+  type: "keep warm";
+  source: "event-bridge";
+};
+
+function isEventBridgeWarm(e: any): e is LambdaWarmerEvent {
+  return (
+    typeof e === "object" &&
+    e !== null &&
+    "source" in e &&
+    (e as any).source === "event-bridge" &&
+    e.type == "keepWarm"
+  );
+}
+
 const BASE_PATH = "/rag";
 const controller = new RagController();
 
@@ -11,8 +26,14 @@ const handlers = {
 };
 
 export const handler = async (
-  event: APIGatewayProxyEvent,
+  event: APIGatewayProxyEvent | LambdaWarmerEvent,
   context: Context
-): Promise<APIGatewayProxyResult> => {
-  return await handleApiCall(event, context, handlers);
+): Promise<APIGatewayProxyResult | undefined> => {
+  if (isEventBridgeWarm(event)) {
+    console.log("Lambda keep-warm ping, skipping heavy logic");
+
+    return Promise.resolve({ statusCode: 200, body: JSON.stringify({ ok: true, warm: true }) });
+  }
+
+  return await handleApiCall(event as APIGatewayProxyEvent, context, handlers);
 };

--- a/server/src/rag/answer.service.ts
+++ b/server/src/rag/answer.service.ts
@@ -4,17 +4,23 @@ import { classifyQuestion } from "./dietQuestionClassifier";
 import { generateAnswer } from "./openai";
 import { buildMetadataFilter, queryPinecone, trimMatches, upsertVectors } from "./pinecone";
 import { RAG_CONSTANTS } from "./config";
-import { getRagSourceRepository } from "./db";
+import { getRagCacheRepository, getRagSourceRepository } from "./db";
 import { RagIngestRequest, RagRequest } from "./types";
 import { UsageMetrics } from "./openai";
 import { ensureRateLimit } from "./rate-limit";
 import { toCitations, toContextBlocks } from "./context";
-import { findCacheHit } from "./pineconeCache";
+import { findCacheHit, storeCacheHit } from "./pineconeCache";
 import { prepareChunks } from "./ingest";
 import { normalizeAndEmbed } from "./embedding";
 import { RagAnswerResponder } from "./responses";
+import { matchDenylistedTopic, BLOCKED_TOPIC_MESSAGES } from "./denylist";
+import { isGreeting } from "./greetings";
+import { runBinaryClassifier, runBinaryClassifierLLM } from "./binaryClassifier";
+import { normalizeText } from "./text";
+import { IRagCacheEntry } from "../models/ragCacheModel";
 
 const sourceRepository = getRagSourceRepository();
+const cacheRepository = getRagCacheRepository();
 
 export const toSseChunk = (payload: Record<string, any>) => `data: ${JSON.stringify(payload)}\n\n`;
 
@@ -38,9 +44,90 @@ export class RagAnswerService {
     await ensureRateLimit(userId);
 
     const languageDetection = detectLanguage(question);
-    const { normalizedQuestion, embedding } = await normalizeAndEmbed(question);
+    const normalizedPlainQuestion = normalizeText(question);
 
-    const Responder = new RagAnswerResponder(userId, question, languageDetection, sessionId, start);
+    const Responder = new RagAnswerResponder(
+      userId,
+      question,
+      languageDetection,
+      sessionId,
+      start,
+      stream
+    );
+
+    if (isGreeting(normalizedPlainQuestion)) {
+      return await Responder.greeting();
+    }
+
+    let normalizedQuestion = normalizedPlainQuestion;
+    let embedding: number[] = [];
+
+    if (RAG_CONSTANTS.denylistEnabled) {
+      const denylistTerm = matchDenylistedTopic(normalizedPlainQuestion);
+      if (denylistTerm) {
+        const existingRefusal = await cacheRepository.findByNormalizedQuestion(
+          userId,
+          normalizedPlainQuestion
+        );
+
+        console.log(
+          JSON.stringify({
+            evt: "rag.blocked_topic",
+            userId,
+            sessionId,
+            term: denylistTerm,
+            cached: existingRefusal?.refusal === true,
+          })
+        );
+
+        if (existingRefusal && existingRefusal.refusal) {
+          return await Responder.cacheHit(existingRefusal);
+        }
+
+        const refusalMessage = BLOCKED_TOPIC_MESSAGES[languageDetection.targetLanguage];
+
+        if (RAG_CONSTANTS.cacheRefusalStubs) {
+          const embedResult = await normalizeAndEmbed(question);
+          normalizedQuestion = embedResult.normalizedQuestion;
+          embedding = embedResult.embedding;
+
+          const refusalDoc: IRagCacheEntry = {
+            userId,
+            question,
+            normalizedQuestion,
+            answer: refusalMessage,
+            language: languageDetection.targetLanguage,
+            citations: [],
+            retrievedIds: [],
+            topScore: 1,
+            embedding,
+            refusal: true,
+            notice: languageDetection.needsFallbackNotice
+              ? RAG_CONSTANTS.languageFallbackNotice
+              : undefined,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          };
+
+          await storeCacheHit(refusalDoc, embedding, userId);
+        }
+
+        return await Responder.refusal({
+          reason: "BLOCKED",
+          message: refusalMessage,
+          cached: false,
+          notice: languageDetection.needsFallbackNotice
+            ? RAG_CONSTANTS.languageFallbackNotice
+            : undefined,
+        });
+      }
+    }
+
+    if (!embedding.length) {
+      const embedResult = await normalizeAndEmbed(question);
+      normalizedQuestion = embedResult.normalizedQuestion;
+      embedding = embedResult.embedding;
+    }
 
     const effectiveCacheThreshold =
       typeof cacheThreshold === "number" ? cacheThreshold : RAG_CONSTANTS.defaultCacheThreshold;
@@ -58,7 +145,62 @@ export class RagAnswerService {
 
     const classification = classifyQuestion(normalizedQuestion, languageDetection.targetLanguage);
 
-    if (!classification.isFitness) {
+    let allowFitness = classification.isFitness;
+
+    if (!allowFitness && RAG_CONSTANTS.binaryClassifierEnabled) {
+      const heuristicStart = Date.now();
+      const binaryResult = runBinaryClassifier(normalizedQuestion);
+
+      console.log(
+        JSON.stringify({
+          evt: "rag.binary_classifier",
+          stage: "HEURISTIC",
+          userId,
+          sessionId,
+          decision: binaryResult.isFitness ? "FITNESS" : "NOT_FITNESS",
+          score: binaryResult.score,
+          matchedPositive: binaryResult.matchedPositive,
+          matchedNegative: binaryResult.matchedNegative,
+          latencyMs: Date.now() - heuristicStart,
+        })
+      );
+
+      allowFitness = binaryResult.isFitness;
+
+      if (!allowFitness) {
+        const llmStart = Date.now();
+        try {
+          const llmResult = await runBinaryClassifierLLM(question);
+
+          console.log(
+            JSON.stringify({
+              evt: "rag.binary_classifier",
+              stage: "LLM",
+              userId,
+              sessionId,
+              decision: llmResult.isFitness ? "FITNESS" : "NOT_FITNESS",
+              latencyMs: Date.now() - llmStart,
+              usage: llmResult.usage,
+              raw: llmResult.raw,
+            })
+          );
+
+          allowFitness = llmResult.isFitness;
+        } catch (error) {
+          console.error(
+            JSON.stringify({
+              evt: "rag.binary_classifier_error",
+              stage: "LLM",
+              userId,
+              sessionId,
+              error: String(error),
+            })
+          );
+        }
+      }
+    }
+
+    if (!allowFitness) {
       return await Responder.notFitness(classification);
     }
 
@@ -96,6 +238,8 @@ export class RagAnswerService {
       return await Responder.retrievalEmpty(matches);
     }
 
+    const noContextFallback = filteredMatches.length === 0;
+
     const citations = toCitations(filteredMatches);
     const contextBlocks = toContextBlocks(filteredMatches);
 
@@ -114,6 +258,7 @@ export class RagAnswerService {
         question,
         summary: undefined,
         stream: true,
+        noContextFallback,
         callbacks: {
           onDelta: (delta) => {
             if (!delta) return;
@@ -135,6 +280,7 @@ export class RagAnswerService {
         question,
         summary: undefined,
         stream: false,
+        noContextFallback,
       });
 
       finalAnswer = result.answer;

--- a/server/src/rag/binaryClassifier.ts
+++ b/server/src/rag/binaryClassifier.ts
@@ -1,0 +1,102 @@
+import { normalizeText } from "./text";
+import {
+  FITNESS_KEYWORDS_EN,
+  FITNESS_KEYWORDS_HE,
+  NON_FITNESS_KEYWORDS,
+} from "./dietQuestionClassifier";
+import { classifyFitnessIntent, BinaryClassifierLLMResult } from "./openai";
+
+const ADDITIONAL_POSITIVE_KEYWORDS = [
+  "gym",
+  "running",
+  "run",
+  "jog",
+  "swim",
+  "yoga",
+  "pilates",
+  "strength",
+  "conditioning",
+  "mobility",
+  "stretching",
+  "meal prep",
+  "meal-prep",
+  "supplements",
+  "supplementation",
+  "macro",
+  "macros",
+  "hydration",
+  "sleep",
+  "rest",
+  "recovery",
+  "cardio",
+  "lifting",
+  "lift",
+];
+
+const ADDITIONAL_POSITIVE_KEYWORDS_HE = [
+  "כושר",
+  "התאוששות",
+  "תזונה",
+  "ארוחה",
+  "ארוחות",
+  "אימוני",
+  "אימון",
+  "נשימה",
+  "ריצה",
+  "שחייה",
+  "פילאטיס",
+  "חיזוק",
+  "גמישות",
+  "שינה",
+  "חלבון",
+];
+
+const POSITIVE_KEYWORDS = Array.from(
+  new Set([
+    ...FITNESS_KEYWORDS_EN,
+    ...FITNESS_KEYWORDS_HE,
+    ...ADDITIONAL_POSITIVE_KEYWORDS,
+    ...ADDITIONAL_POSITIVE_KEYWORDS_HE,
+  ])
+)
+  .map((keyword) => keyword.toLowerCase())
+  .sort((a, b) => a.localeCompare(b));
+
+const NEGATIVE_KEYWORDS = Array.from(new Set(NON_FITNESS_KEYWORDS))
+  .map((keyword) => keyword.toLowerCase())
+  .sort((a, b) => a.localeCompare(b));
+
+export type BinaryClassifierResult = {
+  isFitness: boolean;
+  score: number;
+  matchedPositive: string[];
+  matchedNegative: string[];
+};
+
+const findMatches = (text: string, keywords: string[]): string[] => {
+  const matches = keywords.filter((keyword) => text.includes(keyword));
+  return matches.length ? Array.from(new Set(matches)) : [];
+};
+
+export const runBinaryClassifier = (question: string): BinaryClassifierResult => {
+  const normalized = normalizeText(question).toLowerCase();
+  if (!normalized) {
+    return { isFitness: false, score: 0, matchedPositive: [], matchedNegative: [] };
+  }
+
+  const positiveMatches = findMatches(normalized, POSITIVE_KEYWORDS);
+  const negativeMatches = findMatches(normalized, NEGATIVE_KEYWORDS);
+
+  const score = positiveMatches.length - negativeMatches.length * 1.5;
+
+  return {
+    isFitness: score > 0,
+    score,
+    matchedPositive: positiveMatches,
+    matchedNegative: negativeMatches,
+  };
+};
+
+export const runBinaryClassifierLLM = async (
+  question: string
+): Promise<BinaryClassifierLLMResult> => classifyFitnessIntent(question);

--- a/server/src/rag/config.ts
+++ b/server/src/rag/config.ts
@@ -47,19 +47,12 @@ export const RAG_CONSTANTS = {
     process.env.OPENAI_EMBEDDING_DIMENSIONS,
     DEFAULT_EMBED_DIMENSION
   ),
-  allowFallbackLLMWithoutContext: parseBoolean(
-    process.env.RAG_ALLOW_FALLBACK_LLM,
-    true
-  ),
+  allowFallbackLLMWithoutContext: parseBoolean(process.env.RAG_ALLOW_FALLBACK_LLM, true),
   denylistEnabled: parseBoolean(process.env.RAG_DENYLIST_ENABLED, true),
   binaryClassifierEnabled: parseBoolean(process.env.RAG_BINARY_CLASSIFIER_ENABLED, true),
   cacheRefusalStubs: parseBoolean(process.env.RAG_CACHE_REFUSAL_STUBS, true),
-  binaryClassifierModel:
-    process.env.RAG_BINARY_CLASSIFIER_MODEL || "gpt-4o-mini",
-  binaryClassifierMaxTokens: parsePositiveNumber(
-    process.env.RAG_BINARY_CLASSIFIER_MAX_TOKENS,
-    4
-  ),
+  binaryClassifierModel: process.env.RAG_BINARY_CLASSIFIER_MODEL || "gpt-4o-mini",
+  binaryClassifierMaxTokens: parsePositiveNumber(process.env.RAG_BINARY_CLASSIFIER_MAX_TOKENS, 4),
 };
 
 export const getPineconeIndexName = () => process.env.PINECONE_INDEX || "diet-questions";

--- a/server/src/rag/config.ts
+++ b/server/src/rag/config.ts
@@ -51,12 +51,8 @@ export const RAG_CONSTANTS = {
   denylistEnabled: parseBoolean(process.env.RAG_DENYLIST_ENABLED, true),
   binaryClassifierEnabled: parseBoolean(process.env.RAG_BINARY_CLASSIFIER_ENABLED, true),
   cacheRefusalStubs: parseBoolean(process.env.RAG_CACHE_REFUSAL_STUBS, true),
-  binaryClassifierModel:
-    process.env.RAG_BINARY_CLASSIFIER_MODEL || "gpt-3.5-turbo",
-  binaryClassifierMaxTokens: parsePositiveNumber(
-    process.env.RAG_BINARY_CLASSIFIER_MAX_TOKENS,
-    4
-  ),
+  binaryClassifierModel: process.env.RAG_BINARY_CLASSIFIER_MODEL || "gpt-3.5-turbo",
+  binaryClassifierMaxTokens: parsePositiveNumber(process.env.RAG_BINARY_CLASSIFIER_MAX_TOKENS, 4),
 };
 
 export const getPineconeIndexName = () => process.env.PINECONE_INDEX || "diet-questions";

--- a/server/src/rag/config.ts
+++ b/server/src/rag/config.ts
@@ -55,7 +55,7 @@ export const RAG_CONSTANTS = {
   binaryClassifierEnabled: parseBoolean(process.env.RAG_BINARY_CLASSIFIER_ENABLED, true),
   cacheRefusalStubs: parseBoolean(process.env.RAG_CACHE_REFUSAL_STUBS, true),
   binaryClassifierModel:
-    process.env.RAG_BINARY_CLASSIFIER_MODEL || "gpt-4o-mini",
+    process.env.RAG_BINARY_CLASSIFIER_MODEL || "gpt-3.5-turbo",
   binaryClassifierMaxTokens: parsePositiveNumber(
     process.env.RAG_BINARY_CLASSIFIER_MAX_TOKENS,
     4

--- a/server/src/rag/config.ts
+++ b/server/src/rag/config.ts
@@ -7,6 +7,25 @@ const parsePositiveNumber = (value: string | undefined, fallback: number): numbe
   return fallback;
 };
 
+const parseBoolean = (value: string | undefined, fallback: boolean): boolean => {
+  if (typeof value === "undefined") {
+    return fallback;
+  }
+
+  if (value === "1" || value?.toLowerCase() === "true") {
+    return true;
+  }
+
+  if (value === "0" || value?.toLowerCase() === "false") {
+    return false;
+  }
+
+  return fallback;
+};
+
+const DEFAULT_EMBED_MODEL = "text-embedding-3-small";
+const DEFAULT_EMBED_DIMENSION = 512;
+
 export const RAG_CONSTANTS = {
   cacheNamespace: "semantic-cache",
   corpusNamespace: "corpus",
@@ -16,16 +35,36 @@ export const RAG_CONSTANTS = {
     : 0.5,
   defaultCacheThreshold: Number.isFinite(Number(process.env.RAG_CACHE_THRESHOLD))
     ? Number(process.env.RAG_CACHE_THRESHOLD)
-    : 0.9,
+    : 0.88,
   maxContextChunks: 6,
   minContextSentences: 2,
   languageFallbackNotice: "השאלה זוהתה בשפה שאינה נתמכת, התשובה מסופקת בעברית בהתאם למדיניות.",
   rateLimitWindowMs: parsePositiveNumber(process.env.RAG_RATE_LIMIT_WINDOW_MS, 60_000),
   rateLimitMaxRequests: parsePositiveNumber(process.env.RAG_RATE_LIMIT_MAX_REQUESTS, 8),
   chatModel: process.env.OPENAI_CHAT_MODEL || "gpt-4o-mini",
-  embeddingModel: process.env.OPENAI_EMBEDDING_MODEL || "text-embedding-3-small",
-  embeddingDimensions: parsePositiveNumber(process.env.OPENAI_EMBEDDING_DIMENSIONS, 512),
-  allowFallbackLLMWithoutContext: true,
+  embeddingModel: process.env.OPENAI_EMBEDDING_MODEL || DEFAULT_EMBED_MODEL,
+  embeddingDimensions: parsePositiveNumber(
+    process.env.OPENAI_EMBEDDING_DIMENSIONS,
+    DEFAULT_EMBED_DIMENSION
+  ),
+  allowFallbackLLMWithoutContext: parseBoolean(
+    process.env.RAG_ALLOW_FALLBACK_LLM,
+    true
+  ),
+  denylistEnabled: parseBoolean(process.env.RAG_DENYLIST_ENABLED, true),
+  binaryClassifierEnabled: parseBoolean(process.env.RAG_BINARY_CLASSIFIER_ENABLED, true),
+  cacheRefusalStubs: parseBoolean(process.env.RAG_CACHE_REFUSAL_STUBS, true),
+  binaryClassifierModel:
+    process.env.RAG_BINARY_CLASSIFIER_MODEL || "gpt-4o-mini",
+  binaryClassifierMaxTokens: parsePositiveNumber(
+    process.env.RAG_BINARY_CLASSIFIER_MAX_TOKENS,
+    4
+  ),
 };
 
 export const getPineconeIndexName = () => process.env.PINECONE_INDEX || "diet-questions";
+
+export const EMBEDDING_CONFIG = {
+  model: RAG_CONSTANTS.embeddingModel,
+  dimensions: RAG_CONSTANTS.embeddingDimensions,
+};

--- a/server/src/rag/denylist.ts
+++ b/server/src/rag/denylist.ts
@@ -1,0 +1,60 @@
+import { SupportedLanguage } from "./language";
+import { normalizeText } from "./text";
+
+type DenylistEntry = {
+  term: string;
+  regex: RegExp;
+};
+
+const DENYLIST_ENTRIES: DenylistEntry[] = [
+  { term: "politics", regex: /\bpolitic(?:s|al)?\b/i },
+  { term: "election", regex: /\belection\b/i },
+  { term: "president", regex: /\bpresident\b/i },
+  { term: "government", regex: /\bgovern(?:ment|ance)\b/i },
+  { term: "hitler", regex: /\bhitler\b/i },
+  { term: "nazi", regex: /\bnazi\b/i },
+  { term: "isis", regex: /\bisis\b/i },
+  { term: "terror", regex: /\bterror(?:ism|ist)?\b/i },
+  { term: "extremism", regex: /\bextrem(?:ism|ist)\b/i },
+  { term: "racism", regex: /\braci(?:sm|st)\b/i },
+  { term: "hate speech", regex: /\bhate\s+(?:speech|group|crime)\b/i },
+  { term: "sex", regex: /\bsex(?:ual|\b)/i },
+  { term: "porn", regex: /\bporn(?:ography|\b)/i },
+  { term: "nsfw", regex: /\bnsfw\b/i },
+  { term: "adult", regex: /\badult\s+(?:content|video|film)s?\b/i },
+  { term: "fetish", regex: /\bfetish\b/i },
+  { term: "violence", regex: /\bviolence\b/i },
+  { term: "weapons", regex: /\bweapon(?:s|ry)?\b/i },
+  { term: "suicide", regex: /\bsuicid(?:e|al)\b/i },
+  { term: "self harm", regex: /self\s*harm/i },
+  { term: "politics-he", regex: /פוליט/i },
+  { term: "elections-he", regex: /בחירות/i },
+  { term: "government-he", regex: /ממשלה/i },
+  { term: "president-he", regex: /נשיא/i },
+  { term: "terror-he", regex: /טרור/i },
+  { term: "extremism-he", regex: /קיצונ/i },
+  { term: "hitler-he", regex: /היטלר/i },
+  { term: "nazi-he", regex: /נאצי/i },
+  { term: "sex-he", regex: /סקס|מין/i },
+  { term: "porn-he", regex: /פורנ/i },
+  { term: "nsfw-he", regex: /ארוט/i },
+  { term: "violence-he", regex: /אלימות/i },
+  { term: "weapons-he", regex: /נשק/i },
+  { term: "hate-he", regex: /שנאה/i },
+];
+
+export const BLOCKED_TOPIC_MESSAGES: Record<SupportedLanguage, string> = {
+  he: "מצטערים, לא ניתן לענות על הנושא הזה. אפשר לשאול שאלות על כושר, תזונה ובריאות כללית בלבד.",
+  en: "Sorry, I can't help with that topic. Please ask about fitness, nutrition, or general wellness instead.",
+};
+
+export const matchDenylistedTopic = (rawText: string): string | null => {
+  const text = normalizeText(rawText);
+
+  if (!text) {
+    return null;
+  }
+
+  const entry = DENYLIST_ENTRIES.find((item) => item.regex.test(text));
+  return entry ? entry.term : null;
+};

--- a/server/src/rag/dietQuestionClassifier.ts
+++ b/server/src/rag/dietQuestionClassifier.ts
@@ -126,7 +126,10 @@ export const classifyQuestion = (
   }
 
   const positiveMatches = Array.from(
-    new Set([...findMatches(text, FITNESS_KEYWORDS_EN_LC), ...findMatches(text, FITNESS_KEYWORDS_HE_LC)])
+    new Set([
+      ...findMatches(text, FITNESS_KEYWORDS_EN_LC),
+      ...findMatches(text, FITNESS_KEYWORDS_HE_LC),
+    ])
   );
 
   if (!positiveMatches.length) {

--- a/server/src/rag/dietQuestionClassifier.ts
+++ b/server/src/rag/dietQuestionClassifier.ts
@@ -1,7 +1,7 @@
 import { SupportedLanguage } from "./language";
 import { normalizeText } from "./text";
 
-const FITNESS_KEYWORDS_EN = [
+export const FITNESS_KEYWORDS_EN = [
   "diet",
   "nutrition",
   "protein",
@@ -31,7 +31,7 @@ const FITNESS_KEYWORDS_EN = [
   "cool down",
 ];
 
-const FITNESS_KEYWORDS_HE = [
+export const FITNESS_KEYWORDS_HE = [
   "תזונה",
   "תכנית",
   "תוכנית",
@@ -60,7 +60,7 @@ const FITNESS_KEYWORDS_HE = [
   "סיבולת",
 ];
 
-const NON_FITNESS_KEYWORDS = [
+export const NON_FITNESS_KEYWORDS = [
   "investment",
   "stock",
   "crypto",
@@ -84,10 +84,19 @@ export type ClassificationResult = {
   isFitness: boolean;
   reason: "FITNESS" | "NOT_FITNESS";
   message?: string;
+  positiveMatches: string[];
+  negativeMatches: string[];
 };
 
-const containsKeyword = (text: string, keywords: string[]) =>
-  keywords.some((keyword) => text.includes(keyword));
+const toLowercaseKeywords = (keywords: string[]) =>
+  keywords.map((keyword) => keyword.toLowerCase());
+
+const FITNESS_KEYWORDS_EN_LC = toLowercaseKeywords(FITNESS_KEYWORDS_EN);
+const FITNESS_KEYWORDS_HE_LC = toLowercaseKeywords(FITNESS_KEYWORDS_HE);
+const NON_FITNESS_KEYWORDS_LC = toLowercaseKeywords(NON_FITNESS_KEYWORDS);
+
+const findMatches = (text: string, keywords: string[]) =>
+  keywords.filter((keyword) => text.includes(keyword));
 
 export const classifyQuestion = (
   question: string,
@@ -100,34 +109,35 @@ export const classifyQuestion = (
       isFitness: false,
       reason: "NOT_FITNESS",
       message: NOT_FITNESS_MESSAGES[targetLanguage],
+      positiveMatches: [],
+      negativeMatches: [],
     };
   }
 
-  if (containsKeyword(text, NON_FITNESS_KEYWORDS)) {
+  const negativeMatches = findMatches(text, NON_FITNESS_KEYWORDS_LC);
+  if (negativeMatches.length) {
     return {
       isFitness: false,
       reason: "NOT_FITNESS",
       message: NOT_FITNESS_MESSAGES[targetLanguage],
+      positiveMatches: [],
+      negativeMatches,
     };
   }
 
-  const isFitnessRelated =
-    containsKeyword(
-      text,
-      FITNESS_KEYWORDS_EN.map((k) => k.toLowerCase())
-    ) ||
-    containsKeyword(
-      text,
-      FITNESS_KEYWORDS_HE.map((k) => k.toLowerCase())
-    );
+  const positiveMatches = Array.from(
+    new Set([...findMatches(text, FITNESS_KEYWORDS_EN_LC), ...findMatches(text, FITNESS_KEYWORDS_HE_LC)])
+  );
 
-  if (!isFitnessRelated) {
+  if (!positiveMatches.length) {
     return {
       isFitness: false,
       reason: "NOT_FITNESS",
       message: NOT_FITNESS_MESSAGES[targetLanguage],
+      positiveMatches,
+      negativeMatches,
     };
   }
 
-  return { isFitness: true, reason: "FITNESS" };
+  return { isFitness: true, reason: "FITNESS", positiveMatches, negativeMatches };
 };

--- a/server/src/rag/greetings.ts
+++ b/server/src/rag/greetings.ts
@@ -1,0 +1,38 @@
+import { normalizeText } from "./text";
+
+const GREETING_PATTERNS: RegExp[] = [
+  /^hi(?: there)?$/i,
+  /^hello(?: there)?$/i,
+  /^hey(?: there)?$/i,
+  /^shalom$/i,
+  /^שלום$/,
+  /^בוקר טוב$/,
+  /^ערב טוב$/,
+  /^צהריים טובים$/,
+  /^good (?:morning|afternoon|evening)$/i,
+  /^hiya$/i,
+  /^yo$/i,
+];
+
+export const isGreeting = (rawText: string): boolean => {
+  const text = normalizeText(rawText);
+  if (!text) {
+    return false;
+  }
+
+  if (/[?]/.test(text)) {
+    return false;
+  }
+
+  const cleaned = text.replace(/[!.,]/g, "").trim();
+
+  if (!cleaned) {
+    return false;
+  }
+
+  if (cleaned.length > 40) {
+    return false;
+  }
+
+  return GREETING_PATTERNS.some((pattern) => pattern.test(cleaned));
+};

--- a/server/src/rag/openai.ts
+++ b/server/src/rag/openai.ts
@@ -25,6 +25,12 @@ export type UsageMetrics = {
   totalTokens: number;
 };
 
+export type BinaryClassifierLLMResult = {
+  isFitness: boolean;
+  raw: string;
+  usage?: UsageMetrics;
+};
+
 export type StreamCallbacks = {
   onDelta?: (delta: string) => void;
 };
@@ -36,6 +42,7 @@ export type GenerateAnswerParams = {
   summary?: string;
   stream?: boolean;
   callbacks?: StreamCallbacks;
+  noContextFallback?: boolean;
 };
 
 export type GenerateAnswerResult = {
@@ -46,9 +53,34 @@ export type GenerateAnswerResult = {
 const buildSystemPrompt = (targetLanguage: string) =>
   SYSTEM_PROMPT.replace(/<targetLang>/g, targetLanguage);
 
+const BINARY_CLASSIFIER_SYSTEM_PROMPT = [
+  "You are a concise intent classifier for health, fitness, training, recovery, sleep, and nutrition questions.",
+  "Answer YES if the user is genuinely asking about exercise, diet, healthy lifestyle habits, or how behaviours impact those goals.",
+  "Answer NO if it is trolling, unrelated, or mostly about another topic.",
+  "Respond with a single word: YES or NO.",
+].join(" ");
+
+const buildBinaryClassifierPrompt = (question: string) =>
+  [
+    `Question: """${normalizeText(question)}"""`,
+    "Is this question about fitness, exercise, nutrition, recovery, or how lifestyle factors influence those areas?",
+    "Respond with YES if it is. Otherwise respond with NO.",
+  ].join("\n");
+
 const buildPrompt = (params: GenerateAnswerParams): string => {
-  const { contextBlocks, question, summary } = params;
+  const { contextBlocks, question, summary, noContextFallback } = params;
   const promptParts: string[] = [];
+
+  if (noContextFallback) {
+    promptParts.push(
+      [
+        "No retrieved context is available.",
+        "Provide concise, fitness and wellness-relevant guidance only.",
+        "Do not diagnose; remind users to consult a professional for medical concerns.",
+        "Do not include citations or [^i] markers when no context is provided.",
+      ].join(" ")
+    );
+  }
 
   if (summary) {
     promptParts.push(`Conversation summary: ${summary}`);
@@ -140,6 +172,40 @@ export const generateAnswer = async (
   }
 };
 
+export const classifyFitnessIntent = async (
+  question: string
+): Promise<BinaryClassifierLLMResult> => {
+  const client = getClient();
+  const prompt = buildBinaryClassifierPrompt(question);
+
+  try {
+    const response = await client.chat.completions.create({
+      model: RAG_CONSTANTS.binaryClassifierModel,
+      messages: [
+        { role: "system", content: BINARY_CLASSIFIER_SYSTEM_PROMPT },
+        { role: "user", content: prompt },
+      ],
+      max_tokens: RAG_CONSTANTS.binaryClassifierMaxTokens,
+      temperature: 0,
+    });
+
+    const raw = response.choices?.[0]?.message?.content?.trim?.() || "";
+    const normalized = raw.toUpperCase();
+    const isFitness = normalized.startsWith("Y");
+    const usage: UsageMetrics | undefined = response.usage
+      ? {
+          promptTokens: response.usage.prompt_tokens,
+          completionTokens: response.usage.completion_tokens,
+          totalTokens: response.usage.total_tokens,
+        }
+      : undefined;
+
+    return { isFitness, raw, usage };
+  } catch (error: any) {
+    throw new Error(`OpenAI binary classifier error: ${error?.message || error}`);
+  }
+};
+
 export const createEmbedding = async (text: string): Promise<number[]> => {
   const client = getClient();
   try {
@@ -152,6 +218,13 @@ export const createEmbedding = async (text: string): Promise<number[]> => {
     const embedding = response.data?.[0]?.embedding as number[] | undefined;
     if (!embedding) {
       throw new Error("Embedding not returned by OpenAI");
+    }
+
+    const expected = RAG_CONSTANTS.embeddingDimensions;
+    if (embedding.length !== expected) {
+      throw new Error(
+        `Pinecone index dimension (${expected}) != embedding result dimension (${embedding.length})`
+      );
     }
 
     return embedding;

--- a/server/src/rag/pinecone.ts
+++ b/server/src/rag/pinecone.ts
@@ -45,10 +45,7 @@ const resolveIndexDimension = (description: any): number | undefined => {
   return undefined;
 };
 
-const ensureEmbeddingDimensionConsistency = async (
-  client: Pinecone,
-  indexName: string
-) => {
+const ensureEmbeddingDimensionConsistency = async (client: Pinecone, indexName: string) => {
   if (embeddingDimensionChecked) {
     return;
   }

--- a/server/src/rag/pinecone.ts
+++ b/server/src/rag/pinecone.ts
@@ -1,7 +1,11 @@
 import { Pinecone } from "@pinecone-database/pinecone";
 import { getPineconeIndexName, RAG_CONSTANTS } from "./config";
 
+type PineconeIndex = ReturnType<Pinecone["index"]>;
+
 let cachedClient: Pinecone | null = null;
+let cachedIndexPromise: Promise<PineconeIndex> | null = null;
+let embeddingDimensionChecked = false;
 
 const getClient = () => {
   if (cachedClient) {
@@ -17,10 +21,62 @@ const getClient = () => {
   return cachedClient;
 };
 
-const getIndex = () => {
-  const client = getClient();
-  const indexName = getPineconeIndexName();
-  return client.index(indexName);
+const resolveIndexDimension = (description: any): number | undefined => {
+  if (!description || typeof description !== "object") {
+    return undefined;
+  }
+
+  if (typeof description.dimension === "number") {
+    return description.dimension;
+  }
+
+  if (description.database && typeof description.database.dimension === "number") {
+    return description.database.dimension;
+  }
+
+  if (description.spec && typeof description.spec.dimension === "number") {
+    return description.spec.dimension;
+  }
+
+  if (description.status && typeof description.status.dimension === "number") {
+    return description.status.dimension;
+  }
+
+  return undefined;
+};
+
+const ensureEmbeddingDimensionConsistency = async (
+  client: Pinecone,
+  indexName: string
+) => {
+  if (embeddingDimensionChecked) {
+    return;
+  }
+
+  const description = await client.describeIndex(indexName);
+  const indexDimension = resolveIndexDimension(description);
+  const expected = RAG_CONSTANTS.embeddingDimensions;
+
+  if (typeof indexDimension === "number" && indexDimension !== expected) {
+    throw new Error(
+      `Pinecone index dimension (${indexDimension}) != embedding result dimension (${expected})`
+    );
+  }
+
+  embeddingDimensionChecked = true;
+};
+
+const getIndex = async (): Promise<PineconeIndex> => {
+  if (!cachedIndexPromise) {
+    cachedIndexPromise = (async () => {
+      const client = getClient();
+      const indexName = getPineconeIndexName();
+      await ensureEmbeddingDimensionConsistency(client, indexName);
+      return client.index(indexName);
+    })();
+  }
+
+  return cachedIndexPromise;
 };
 
 export type PineconeMatch = {
@@ -44,7 +100,7 @@ export type UpsertVector = {
 };
 
 export const queryPinecone = async (options: QueryOptions): Promise<PineconeMatch[]> => {
-  const index = getIndex();
+  const index = await getIndex();
   const namespace = index.namespace(options.namespace);
   const response = await namespace.query({
     topK: options.topK,
@@ -61,7 +117,7 @@ export const upsertVectors = async (namespace: string, vectors: UpsertVector[]) 
     return;
   }
 
-  const index = getIndex();
+  const index = await getIndex();
   const namespaceClient = index.namespace(namespace);
   const payload = vectors.map((vector) => ({
     id: vector.id,
@@ -77,7 +133,7 @@ export const deleteVectors = async (namespace: string, ids: string[]) => {
     return;
   }
 
-  const index = getIndex();
+  const index = await getIndex();
   const namespaceClient = index.namespace(namespace);
   const deleteMany = (namespaceClient as any).deleteMany as
     | ((ids: string[]) => Promise<void>)

--- a/server/src/rag/pineconeCache.ts
+++ b/server/src/rag/pineconeCache.ts
@@ -1,11 +1,18 @@
 import { IRagCacheEntry } from "../models/ragCacheModel";
 import { RAG_CONSTANTS } from "./config";
 import { getRagCacheRepository } from "./db";
-import { queryPinecone, buildMetadataFilter, upsertVectors } from "./pinecone";
+import {
+  queryPinecone,
+  buildMetadataFilter,
+  upsertVectors,
+  deleteVectors,
+} from "./pinecone";
 
 const cacheRepository = getRagCacheRepository();
 
 const cacheVectorId = (cacheId: string, userId: string) => `cache-${userId}-${cacheId}`;
+
+const log = (obj: Record<string, any>) => console.log(JSON.stringify(obj));
 
 const findCacheHit = async (
   userId: string,
@@ -20,10 +27,41 @@ const findCacheHit = async (
     filter: buildMetadataFilter(userId, language),
   });
 
-  if (!matches.length) return null;
+  if (!matches.length) {
+    log({
+      evt: "rag.cache_miss",
+      userId,
+      reason: "NO_MATCHES",
+      cacheThreshold,
+      bestScore: null,
+      bestNormalizedQuestion: undefined,
+    });
+    return null;
+  }
 
   const [best] = matches;
+  const bestScore = best?.score ?? null;
+  const bestNormalizedQuestion =
+    typeof best?.metadata?.normalizedQuestion === "string"
+      ? (best?.metadata?.normalizedQuestion as string)
+      : undefined;
+
+  let missLogged = false;
+  const logMiss = (reason: string) => {
+    if (missLogged) return;
+    missLogged = true;
+    log({
+      evt: "rag.cache_miss",
+      userId,
+      reason,
+      cacheThreshold,
+      bestScore,
+      bestNormalizedQuestion,
+    });
+  };
+
   if (!best || (best.score || 0) < cacheThreshold) {
+    logMiss(!best ? "NO_MATCH_ABOVE_THRESHOLD" : "BELOW_THRESHOLD");
     return null;
   }
 
@@ -33,13 +71,29 @@ const findCacheHit = async (
     if (cacheDoc) {
       return cacheDoc;
     }
+
+    log({ evt: "rag.cache_stale", cacheId, userId });
+
+    try {
+      await deleteVectors(RAG_CONSTANTS.cacheNamespace, [cacheVectorId(cacheId, userId)]);
+    } catch (error) {
+      log({ evt: "rag.cache_stale_delete_failed", cacheId, userId, error: String(error) });
+    }
+    logMiss("STALE_CACHE");
   }
 
   const normalizedQuestion = best.metadata?.normalizedQuestion as string | undefined;
   if (normalizedQuestion) {
-    return await cacheRepository.findByNormalizedQuestion(userId, normalizedQuestion);
+    const docByNormalized = await cacheRepository.findByNormalizedQuestion(
+      userId,
+      normalizedQuestion
+    );
+    if (docByNormalized) {
+      return docByNormalized;
+    }
   }
 
+  logMiss("MONGO_LOOKUP_MISS");
   return null;
 };
 
@@ -58,6 +112,7 @@ const storeCacheHit = async (doc: IRagCacheEntry, embedding: number[], userId: s
         cacheId,
         retrievedIds: doc.retrievedIds,
         topScore: doc.topScore,
+        refusal: doc.refusal,
       },
     },
   ]);

--- a/server/src/rag/pineconeCache.ts
+++ b/server/src/rag/pineconeCache.ts
@@ -1,12 +1,7 @@
 import { IRagCacheEntry } from "../models/ragCacheModel";
 import { RAG_CONSTANTS } from "./config";
 import { getRagCacheRepository } from "./db";
-import {
-  queryPinecone,
-  buildMetadataFilter,
-  upsertVectors,
-  deleteVectors,
-} from "./pinecone";
+import { queryPinecone, buildMetadataFilter, upsertVectors, deleteVectors } from "./pinecone";
 
 const cacheRepository = getRagCacheRepository();
 

--- a/server/src/rag/prompts.ts
+++ b/server/src/rag/prompts.ts
@@ -1,6 +1,7 @@
 export const SYSTEM_PROMPT = [
   "General fitness and wellness guidance only; never diagnose or give medical directives—advise consulting a professional for injuries, conditions, or symptoms.",
   "Use ONLY the provided context; if the context lacks an answer, respond that you don't know.",
+  "When no context is provided you must lean on general safety guidance, stay concise, and avoid citations.",
   "Respond in <targetLang>; when context sources mix languages, summarise them into <targetLang>.",
-  "Cite sources as [^i] in order, including source ids or URLs when present.",
+  "Cite sources as [^i] in order when context is provided, including source ids or URLs when present; omit citations entirely when no context exists.",
 ].join(" ");

--- a/server/src/rag/responses.ts
+++ b/server/src/rag/responses.ts
@@ -1,6 +1,6 @@
 import { ClassificationResult, NOT_FITNESS_MESSAGES } from "./dietQuestionClassifier";
 import { logTrace } from "./trace";
-import { Citation, RagResponse, RagStreamTrailer } from "./types";
+import { Citation, RagReason, RagResponse, RagStreamTrailer } from "./types";
 import { toSseChunk } from "./answer.service";
 import { LanguageDetection } from "./language";
 import { IRagCacheEntry } from "../models/ragCacheModel";
@@ -31,6 +31,52 @@ export class RagAnswerResponder {
     private readonly logger: (obj: any) => void = (o) => console.log(JSON.stringify(o))
   ) {}
 
+  async greeting(): Promise<BranchResult> {
+    const response: RagResponse = {
+      reason: "GREETING",
+      answer: "",
+      citations: [],
+      cached: false,
+      greeting: true,
+    };
+
+    const trailer: RagStreamTrailer = { done: true, citations: [] };
+    const events = this.stream ? [toSseChunk(trailer)] : [];
+
+    await this.traceFn(
+      this.userId,
+      this.question,
+      this.languageDetection.targetLanguage,
+      "GREETING",
+      "",
+      [],
+      undefined,
+      this.sessionId
+    );
+
+    this.logger({
+      evt: "rag.query",
+      reason: "GREETING",
+      userId: this.userId,
+      sessionId: this.sessionId,
+      language: this.languageDetection.targetLanguage,
+      cached: false,
+      latencyMs: Date.now() - this.start,
+      topScores: [],
+      retrievedIds: [],
+      usage: undefined,
+    });
+
+    return {
+      response,
+      stream: this.stream,
+      events,
+      trailer,
+      matches: [],
+      languageDetection: this.languageDetection,
+    };
+  }
+
   /** NOT_FITNESS branch */
   async notFitness(classification: ClassificationResult): Promise<BranchResult> {
     const message =
@@ -41,6 +87,7 @@ export class RagAnswerResponder {
       answer: message,
       citations: [],
       cached: false,
+      refusal: true,
     };
 
     const trailer: RagStreamTrailer = { done: true, citations: [] };
@@ -67,6 +114,7 @@ export class RagAnswerResponder {
       latencyMs: Date.now() - this.start,
       topScores: [],
       retrievedIds: [],
+      usage: undefined,
     });
 
     return {
@@ -81,13 +129,15 @@ export class RagAnswerResponder {
 
   /** CACHE_HIT branch */
   async cacheHit(cacheHit: IRagCacheEntry): Promise<BranchResult> {
+    const reason = cacheHit.refusal ? "CACHE_REFUSAL" : "CACHE_HIT";
     const response: RagResponse = {
-      reason: "CACHE_HIT",
+      reason,
       answer: cacheHit.answer,
       citations: cacheHit.citations,
       usage: undefined,
       cached: true,
       notice: cacheHit.notice,
+      refusal: cacheHit.refusal,
     };
 
     const trailer: RagStreamTrailer = { done: true, citations: cacheHit.citations };
@@ -102,7 +152,7 @@ export class RagAnswerResponder {
       this.userId,
       this.question,
       this.languageDetection.targetLanguage,
-      "CACHE_HIT",
+      reason,
       cacheHit.answer,
       cacheHit.retrievedIds,
       undefined,
@@ -111,14 +161,15 @@ export class RagAnswerResponder {
 
     this.logger({
       evt: "rag.query",
-      reason: "CACHE_HIT",
+      reason,
       userId: this.userId,
       sessionId: this.sessionId,
       language: this.languageDetection.targetLanguage,
       cached: true,
       latencyMs: Date.now() - this.start,
-      topScores: [cacheHit.topScore],
-      retrievedIds: cacheHit.retrievedIds,
+      topScores: typeof cacheHit.topScore === "number" ? [cacheHit.topScore] : [],
+      retrievedIds: cacheHit.retrievedIds || [],
+      usage: undefined,
     });
 
     return {
@@ -169,6 +220,61 @@ export class RagAnswerResponder {
       latencyMs: Date.now() - this.start,
       topScores: matches.map((m) => m.score),
       retrievedIds: [],
+      usage: undefined,
+    });
+
+    return {
+      response,
+      stream: this.stream,
+      events,
+      trailer,
+      matches: [],
+      languageDetection: this.languageDetection,
+    };
+  }
+
+  async refusal(args: {
+    reason: RagReason;
+    message: string;
+    cached: boolean;
+    notice?: string;
+  }): Promise<BranchResult> {
+    const { reason, message, cached, notice } = args;
+
+    const response: RagResponse = {
+      reason,
+      answer: message,
+      citations: [],
+      cached,
+      notice,
+      refusal: true,
+    };
+
+    const trailer: RagStreamTrailer = { done: true, citations: [] };
+    const events = this.stream ? [toSseChunk({ delta: message }), toSseChunk(trailer)] : [];
+
+    await this.traceFn(
+      this.userId,
+      this.question,
+      this.languageDetection.targetLanguage,
+      reason,
+      message,
+      [],
+      undefined,
+      this.sessionId
+    );
+
+    this.logger({
+      evt: "rag.query",
+      reason,
+      userId: this.userId,
+      sessionId: this.sessionId,
+      language: this.languageDetection.targetLanguage,
+      cached,
+      latencyMs: Date.now() - this.start,
+      topScores: [],
+      retrievedIds: [],
+      usage: undefined,
     });
 
     return {

--- a/server/src/rag/responses.ts
+++ b/server/src/rag/responses.ts
@@ -54,19 +54,6 @@ export class RagAnswerResponder {
       this.sessionId
     );
 
-    this.logger({
-      evt: "rag.query",
-      reason: "GREETING",
-      userId: this.userId,
-      sessionId: this.sessionId,
-      language: this.languageDetection.targetLanguage,
-      cached: false,
-      latencyMs: Date.now() - this.start,
-      topScores: [],
-      retrievedIds: [],
-      usage: undefined,
-    });
-
     return {
       response,
       stream: this.stream,

--- a/server/src/rag/types.ts
+++ b/server/src/rag/types.ts
@@ -4,8 +4,11 @@ import { SupportedLanguage } from "./language";
 
 export type RagReason =
   | "CACHE_HIT"
+  | "CACHE_REFUSAL"
   | "CACHE_MISS"
   | "CACHE_STORED"
+  | "GREETING"
+  | "BLOCKED"
   | "NOT_FITNESS"
   | "RETRIEVAL_EMPTY"
   | "ANSWER_GENERATED";
@@ -44,6 +47,8 @@ export type RagResponse = {
   usage?: UsageMetrics;
   cached?: boolean;
   notice?: string;
+  refusal?: boolean;
+  greeting?: boolean;
 };
 
 export type RagStreamTrailer = {


### PR DESCRIPTION
## Summary
- add an OpenAI yes/no classifier fallback after the heuristic binary gate and log both stages with usage metadata
- expose configuration for the cheap classifier model/tokens, update docs, and return the LLM result to the intent gate
- reuse a cached Pinecone index promise so the embedding dimension check only happens once per process

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f50db02e50832ba2968974a24abc13