### PR TITLE
Add Mongo-backed daily quota and pause guard for RAG service

### DIFF
--- a/server/config/lambdaConfig.js
+++ b/server/config/lambdaConfig.js
@@ -1,5 +1,5 @@
 const lambdaConfig = {
-  timeout: 15,
+  timeout: 25,
 };
 
 module.exports = {

--- a/server/docs/changelog.md
+++ b/server/docs/changelog.md
@@ -1,0 +1,22 @@
+# RAG Service Changelog
+
+## 2025-10-22 — Daily Quota & Pause Guards
+
+### Backend Summary
+- Added a Mongo-backed per-user daily quota counter enforced ahead of the existing sliding-window limiter.
+- Introduced a Mongo-configurable pause switch with a 60s in-memory cache to short-circuit queries while maintenance is underway.
+- Surfaced structured error payloads for quota exhaustion (`code: "DAILY_LIMIT_REACHED"`) and system pauses (`code: "SERVICE_PAUSED"`).
+
+### Frontend Implementation Notes
+1. **Daily quota handling**
+   - Treat HTTP 429 responses that include `code: "DAILY_LIMIT_REACHED"` as a hard stop for the rest of the UTC day.
+   - Read the `limit` integer and `resetAt` ISO timestamp from the payload; display both in your UI (banner, modal, or toast).
+   - Disable submission controls until `resetAt` passes or the backend resumes normal responses.
+2. **System pause handling**
+   - For HTTP 503 responses carrying `code: "SERVICE_PAUSED"`, show the returned `message` verbatim to the user.
+   - Hide or disable the ask interface and provide an optional passive retry button.
+   - Polling is optional; a manual retry after the pause is lifted is sufficient.
+3. **Telemetry**
+   - Log these states client-side (e.g., analytics events `rag.daily_quota_hit` and `rag.service_paused`) with the associated user/session identifiers to aid support triage.
+
+These steps keep the frontend in lockstep with the new operational guardrails without altering the existing streaming or caching flows.

--- a/server/docs/changelog.md
+++ b/server/docs/changelog.md
@@ -3,11 +3,13 @@
 ## 2025-10-22 — Daily Quota & Pause Guards
 
 ### Backend Summary
+
 - Added a Mongo-backed per-user daily quota counter enforced ahead of the existing sliding-window limiter.
 - Introduced a Mongo-configurable pause switch with a 60s in-memory cache to short-circuit queries while maintenance is underway.
 - Surfaced structured error payloads for quota exhaustion (`code: "DAILY_LIMIT_REACHED"`) and system pauses (`code: "SERVICE_PAUSED"`).
 
 ### Frontend Implementation Notes
+
 1. **Daily quota handling**
    - Treat HTTP 429 responses that include `code: "DAILY_LIMIT_REACHED"` as a hard stop for the rest of the UTC day.
    - Read the `limit` integer and `resetAt` ISO timestamp from the payload; display both in your UI (banner, modal, or toast).

--- a/server/docs/rag-frontend-integration.md
+++ b/server/docs/rag-frontend-integration.md
@@ -98,12 +98,12 @@ Before retrieval, the service embeds the normalized question and queries the sem
 
 | Status | Cause                                                                    | UI Suggestion                                                                 |
 | ------ | ------------------------------------------------------------------------ | ----------------------------------------------------------------------------- |
-| 400    | Missing `userId`/`question` or malformed ingest payload                  | Prompt user to correct the form.                                             |
-| 403    | Ingest attempted without admin privileges                                | Show “Admins only” message.                                                  |
-| 429    | Rate limit exceeded in the current 60s window                            | Display a cooldown timer or retry CTA.                                       |
+| 400    | Missing `userId`/`question` or malformed ingest payload                  | Prompt user to correct the form.                                              |
+| 403    | Ingest attempted without admin privileges                                | Show “Admins only” message.                                                   |
+| 429    | Rate limit exceeded in the current 60s window                            | Display a cooldown timer or retry CTA.                                        |
 | 429    | Daily question quota reached (see `limit` + `resetAt` fields in payload) | Surface a “Daily limit reached” banner, disable the form until the reset ETA. |
-| 503    | Backend placed in maintenance pause (`code: "SERVICE_PAUSED"`)          | Show the pause message returned by the server and hide/disable the ask form.  |
-| 500    | Unexpected backend failure                                               | Offer retry and log the incident.                                            |
+| 503    | Backend placed in maintenance pause (`code: "SERVICE_PAUSED"`)           | Show the pause message returned by the server and hide/disable the ask form.  |
+| 500    | Unexpected backend failure                                               | Offer retry and log the incident.                                             |
 
 Source references: validation and rate limit enforcement in `RagAnswerService`, admin guard in `RagController`.【F:server/src/rag/answer.service.ts†L55-L90】【F:server/src/rag/answer.service.ts†L528-L559】【F:server/src/controllers/ragController.ts†L18-L101】
 

--- a/server/docs/rag-frontend-integration.md
+++ b/server/docs/rag-frontend-integration.md
@@ -96,12 +96,14 @@ Before retrieval, the service embeds the normalized question and queries the sem
 
 ## Error Handling Summary
 
-| Status | Cause                                                   | UI Suggestion                          |
-| ------ | ------------------------------------------------------- | -------------------------------------- |
-| 400    | Missing `userId`/`question` or malformed ingest payload | Prompt user to correct the form.       |
-| 403    | Ingest attempted without admin privileges               | Show “Admins only” message.            |
-| 429    | Rate limit exceeded in the current 60s window           | Display a cooldown timer or retry CTA. |
-| 500    | Unexpected backend failure                              | Offer retry and log the incident.      |
+| Status | Cause                                                                    | UI Suggestion                                                                 |
+| ------ | ------------------------------------------------------------------------ | ----------------------------------------------------------------------------- |
+| 400    | Missing `userId`/`question` or malformed ingest payload                  | Prompt user to correct the form.                                             |
+| 403    | Ingest attempted without admin privileges                                | Show “Admins only” message.                                                  |
+| 429    | Rate limit exceeded in the current 60s window                            | Display a cooldown timer or retry CTA.                                       |
+| 429    | Daily question quota reached (see `limit` + `resetAt` fields in payload) | Surface a “Daily limit reached” banner, disable the form until the reset ETA. |
+| 503    | Backend placed in maintenance pause (`code: "SERVICE_PAUSED"`)          | Show the pause message returned by the server and hide/disable the ask form.  |
+| 500    | Unexpected backend failure                                               | Offer retry and log the incident.                                            |
 
 Source references: validation and rate limit enforcement in `RagAnswerService`, admin guard in `RagController`.【F:server/src/rag/answer.service.ts†L55-L90】【F:server/src/rag/answer.service.ts†L528-L559】【F:server/src/controllers/ragController.ts†L18-L101】
 
@@ -124,4 +126,9 @@ Each query logs a structured event containing reason, language, latency, retriev
 5. **Error UX:** Handle 4xx/5xx responses gracefully (cooldown timers, retry flows, support links).
 6. **Admin Tools:** Offer a simple form or script for `/rag/ingest` that batches curated chunks and reports inserted counts.
 
-Following these steps keeps the frontend aligned with semantic caching, HE/EN language policy, and the chatbot’s citation contract.
+Additional UI hooks introduced with the daily quota and pause guards:
+
+- **Daily quota breach:** watch for HTTP 429 responses whose body includes `code: "DAILY_LIMIT_REACHED"`, `limit`, and `resetAt`. Show a non-dismissable alert with the reset timestamp and prevent additional submissions until the reset time or after a successful retry.
+- **System pause:** when the backend responds with HTTP 503 and `code: "SERVICE_PAUSED"`, display the provided `message` verbatim. Offer a passive retry button that re-issues the request when the user believes service has resumed.
+
+Following these steps keeps the frontend aligned with semantic caching, HE/EN language policy, the chatbot’s citation contract, and the new operational guardrails.

--- a/server/src/controllers/ragController.ts
+++ b/server/src/controllers/ragController.ts
@@ -71,10 +71,25 @@ export class RagController {
     } catch (error: any) {
       console.error("rag.ask error", error);
       const status = error?.status || StatusCode.INTERNAL_SERVER_ERROR;
-      const message = error?.message || "Failed to process request";
+      const payload: Record<string, any> = {
+        message: error?.message || "Failed to process request",
+      };
+
+      if (error?.code) {
+        payload.code = error.code;
+      }
+
+      if (typeof error?.limit !== "undefined") {
+        payload.limit = error.limit;
+      }
+
+      if (typeof error?.resetAt !== "undefined") {
+        payload.resetAt = error.resetAt;
+      }
+
       return {
         statusCode: status,
-        body: JSON.stringify({ message }),
+        body: JSON.stringify(payload),
         headers: API_HEADERS,
       };
     }

--- a/server/src/models/ragDailyQuotaModel.ts
+++ b/server/src/models/ragDailyQuotaModel.ts
@@ -1,0 +1,16 @@
+import { Schema, model, InferSchemaType } from "mongoose";
+
+const RagDailyQuotaSchema = new Schema(
+  {
+    userId: { type: String, index: true, required: true },
+    date: { type: String, index: true, required: true }, // "YYYY-MM-DD" in UTC
+    count: { type: Number, required: true, default: 0 },
+    updatedAt: { type: Date, default: () => new Date() },
+  },
+  { versionKey: false }
+);
+
+RagDailyQuotaSchema.index({ userId: 1, date: 1 }, { unique: true });
+
+export type IRagDailyQuota = InferSchemaType<typeof RagDailyQuotaSchema>;
+export default model<IRagDailyQuota>("RagDailyQuota", RagDailyQuotaSchema);

--- a/server/src/models/ragTraceModel.ts
+++ b/server/src/models/ragTraceModel.ts
@@ -25,7 +25,15 @@ const ragTraceSchema = new Schema<IRagTrace>(
     language: { type: String, required: true },
     retrievedIds: { type: [String], default: [] },
     reason: { type: String, required: true },
-    answerPreview: { type: String, required: true },
+    answerPreview: {
+      type: String,
+      required: true,
+      validator: {
+        validate: (preview: string) => {
+          return preview.length > 0 ? preview : "EMPTY TRACE";
+        },
+      },
+    },
     usage: {
       promptTokens: Number,
       completionTokens: Number,

--- a/server/src/models/systemStatusModel.ts
+++ b/server/src/models/systemStatusModel.ts
@@ -1,0 +1,14 @@
+import { Schema, model, InferSchemaType } from "mongoose";
+
+const SystemStatusSchema = new Schema(
+  {
+    key: { type: String, required: true, unique: true }, // always "system"
+    paused: { type: Boolean, default: false },
+    message: { type: String, default: "" },
+    updatedAt: { type: Date, default: () => new Date() },
+  },
+  { versionKey: false }
+);
+
+export type ISystemStatus = InferSchemaType<typeof SystemStatusSchema>;
+export default model<ISystemStatus>("SystemStatus", SystemStatusSchema);

--- a/server/src/rag/answer.service.ts
+++ b/server/src/rag/answer.service.ts
@@ -3,8 +3,13 @@ import { detectLanguage } from "./language";
 import { classifyQuestion } from "./dietQuestionClassifier";
 import { generateAnswer } from "./openai";
 import { buildMetadataFilter, queryPinecone, trimMatches, upsertVectors } from "./pinecone";
-import { RAG_CONSTANTS } from "./config";
-import { getRagCacheRepository, getRagSourceRepository } from "./db";
+import { RAG_CONSTANTS, RAG_LIMITS } from "./config";
+import {
+  getRagCacheRepository,
+  getRagDailyQuotaRepository,
+  getRagSourceRepository,
+  getSystemStatusRepository,
+} from "./db";
 import { RagIngestRequest, RagRequest } from "./types";
 import { UsageMetrics } from "./openai";
 import { ensureRateLimit } from "./rate-limit";
@@ -18,9 +23,57 @@ import { isGreeting } from "./greetings";
 import { runBinaryClassifier, runBinaryClassifierLLM } from "./binaryClassifier";
 import { normalizeText } from "./text";
 import { IRagCacheEntry } from "../models/ragCacheModel";
+import { yyyymmddUTC, nextUTCmidnightISO } from "./utils/date";
 
 const sourceRepository = getRagSourceRepository();
 const cacheRepository = getRagCacheRepository();
+const dailyQuotaRepository = getRagDailyQuotaRepository();
+const systemStatusRepository = getSystemStatusRepository();
+
+export async function ensureNotPausedOrThrow() {
+  const { paused, message } = await systemStatusRepository.get();
+  if (paused) {
+    console.log(
+      JSON.stringify({
+        evt: "rag.paused",
+        reason: message,
+      })
+    );
+
+    const err: any = {
+      status: StatusCode.SERVICE_UNAVAILABLE,
+      message: message || "service temporarily paused",
+      code: "SERVICE_PAUSED",
+    };
+    throw err;
+  }
+}
+
+export async function ensureDailyQuotaOrThrow(userId: string) {
+  const date = yyyymmddUTC();
+  const doc = await dailyQuotaRepository.incAndGet({ userId, date });
+  if (doc && doc.count > RAG_LIMITS.perUserDailyLimit) {
+    console.log(
+      JSON.stringify({
+        evt: "rag.quota",
+        userId,
+        date,
+        count: doc.count,
+        limit: RAG_LIMITS.perUserDailyLimit,
+      })
+    );
+
+    const resetAt = nextUTCmidnightISO();
+    const err: any = {
+      status: StatusCode.TOO_MANY_REQUESTS,
+      message: "daily limit reached",
+      code: "DAILY_LIMIT_REACHED",
+      limit: RAG_LIMITS.perUserDailyLimit,
+      resetAt,
+    };
+    throw err;
+  }
+}
 
 export const toSseChunk = (payload: Record<string, any>) => `data: ${JSON.stringify(payload)}\n\n`;
 
@@ -41,6 +94,8 @@ export class RagAnswerService {
     if (!userId || !question) {
       throw { status: StatusCode.BAD_REQUEST, message: "userId and question are required" };
     }
+    await ensureNotPausedOrThrow();
+    await ensureDailyQuotaOrThrow(userId);
     await ensureRateLimit(userId);
 
     const languageDetection = detectLanguage(question);

--- a/server/src/rag/config.ts
+++ b/server/src/rag/config.ts
@@ -56,11 +56,8 @@ export const RAG_CONSTANTS = {
 };
 
 export const RAG_LIMITS = {
-  perUserDailyLimit: 50, // hard cap per user per UTC day
+  perUserDailyLimit: 30, // hard cap per user per UTC day
 } as const;
-
-// Cost note: if N users all hit 50 Q/day, that's N*50/day ≈ N*1,500 Q/month.
-// With gpt-4o-mini (~$0.000285 per non-cached Q, rough), 100 users ≈ 150k Q/mo ≈ $42.75 (before cache).
 
 export const getPineconeIndexName = () => process.env.PINECONE_INDEX || "diet-questions";
 

--- a/server/src/rag/config.ts
+++ b/server/src/rag/config.ts
@@ -55,6 +55,13 @@ export const RAG_CONSTANTS = {
   binaryClassifierMaxTokens: parsePositiveNumber(process.env.RAG_BINARY_CLASSIFIER_MAX_TOKENS, 4),
 };
 
+export const RAG_LIMITS = {
+  perUserDailyLimit: 50, // hard cap per user per UTC day
+} as const;
+
+// Cost note: if N users all hit 50 Q/day, that's N*50/day ≈ N*1,500 Q/month.
+// With gpt-4o-mini (~$0.000285 per non-cached Q, rough), 100 users ≈ 150k Q/mo ≈ $42.75 (before cache).
+
 export const getPineconeIndexName = () => process.env.PINECONE_INDEX || "diet-questions";
 
 export const EMBEDDING_CONFIG = {

--- a/server/src/rag/db.ts
+++ b/server/src/rag/db.ts
@@ -2,6 +2,8 @@ import { RagCacheRepository } from "../repositories/Rag/RagCacheRepository";
 import { RagTraceRepository } from "../repositories/Rag/RagTraceRepository";
 import { RagRateLimitRepository } from "../repositories/Rag/RagRateLimitRepository";
 import { RagSourceRepository } from "../repositories/Rag/RagSourceRepository";
+import RagDailyQuotaModel from "../models/ragDailyQuotaModel";
+import SystemStatusModel from "../models/systemStatusModel";
 
 const ragCacheRepository = new RagCacheRepository();
 const ragTraceRepository = new RagTraceRepository();
@@ -12,3 +14,50 @@ export const getRagCacheRepository = () => ragCacheRepository;
 export const getRagTraceRepository = () => ragTraceRepository;
 export const getRagRateLimitRepository = () => ragRateLimitRepository;
 export const getRagSourceRepository = () => ragSourceRepository;
+
+export function getRagDailyQuotaRepository() {
+  return {
+    async incAndGet({ userId, date }: { userId: string; date: string }) {
+      const now = new Date();
+      const doc = await RagDailyQuotaModel.findOneAndUpdate(
+        { userId, date },
+        { $inc: { count: 1 }, $set: { updatedAt: now } },
+        { new: true, upsert: true }
+      ).lean();
+      return doc;
+    },
+    async get({ userId, date }: { userId: string; date: string }) {
+      return RagDailyQuotaModel.findOne({ userId, date }).lean();
+    },
+  };
+}
+
+let _cachedStatus: { paused: boolean; message?: string; ts: number } | null = null;
+const STATUS_TTL_MS = 60_000;
+
+export function getSystemStatusRepository() {
+  return {
+    async get(): Promise<{ paused: boolean; message?: string }> {
+      const now = Date.now();
+      if (_cachedStatus && now - _cachedStatus.ts < STATUS_TTL_MS) {
+        return { paused: _cachedStatus.paused, message: _cachedStatus.message };
+      }
+      const doc = await SystemStatusModel.findOne({ key: "system" }).lean();
+      const res = { paused: !!doc?.paused, message: doc?.message || "" };
+      _cachedStatus = { ...res, ts: now };
+      return res;
+    },
+    async setPaused(paused: boolean, message = "") {
+      const now = new Date();
+      await SystemStatusModel.findOneAndUpdate(
+        { key: "system" },
+        { $set: { paused, message, updatedAt: now } },
+        { upsert: true }
+      );
+      _cachedStatus = { paused, message, ts: Date.now() };
+    },
+    async clearCache() {
+      _cachedStatus = null;
+    },
+  };
+}

--- a/server/src/rag/utils/date.ts
+++ b/server/src/rag/utils/date.ts
@@ -1,0 +1,11 @@
+export function yyyymmddUTC(d = new Date()) {
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(d.getUTCDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+export function nextUTCmidnightISO(d = new Date()) {
+  const n = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate() + 1, 0, 0, 0));
+  return n.toISOString();
+}


### PR DESCRIPTION
## Summary
- add configurable daily RAG quota constant and supporting Mongo models/repos
- provide a cached system status repository to power an optional pause switch
- enforce pause and daily quota guards ahead of the existing rate limiter and surface structured error payloads

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f8f93d9af0832b80cbe6dba8da3374