### PR TITLE
feat: add Google Sheets signup and admin leads endpoints

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -16,6 +16,7 @@
     "@pinecone-database/pinecone": "^6.0.1",
     "aws-sdk": "^2.1690.0",
     "bcryptjs": "^2.4.3",
+    "googleapis": "^134.0.0",
     "joi": "^17.6.0",
     "mongoose": "^8.16.5",
     "nodemailer": "^7.0.5",

--- a/server/src/controllers/AdminLeadsController.ts
+++ b/server/src/controllers/AdminLeadsController.ts
@@ -1,0 +1,29 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
+import BaseController from "./BaseController";
+import AdminLeadsService from "../services/AdminLeadsService";
+import { StatusCode } from "../enums/StatusCode";
+
+export default class AdminLeadsController extends BaseController<any, AdminLeadsService> {
+  constructor() {
+    super(new AdminLeadsService());
+  }
+
+  getLeads = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+    await this.beforeAction(event);
+    try {
+      const leads = await this.service.getLeads();
+      const response = {
+        statusCode: StatusCode.OK,
+        body: JSON.stringify(leads),
+      };
+      await this.afterAction(response);
+      return response;
+    } catch (error) {
+      console.error("[AdminLeadsController] Failed to fetch leads", error);
+      return {
+        statusCode: StatusCode.INTERNAL_SERVER_ERROR,
+        body: JSON.stringify({ error: "Failed to fetch leads" }),
+      };
+    }
+  };
+}

--- a/server/src/controllers/PublicSignupController.ts
+++ b/server/src/controllers/PublicSignupController.ts
@@ -23,7 +23,10 @@ export default class PublicSignupController extends BaseController<any, PublicSi
 
     try {
       const body = extractBodyFromEvent(event);
-      const { error, value } = signupSchema.validate(body, { abortEarly: false, stripUnknown: true });
+      const { error, value } = signupSchema.validate(body, {
+        abortEarly: false,
+        stripUnknown: true,
+      });
 
       if (error) {
         return {
@@ -32,13 +35,15 @@ export default class PublicSignupController extends BaseController<any, PublicSi
         };
       }
 
-      const result = await this.service.submitSignup(value as {
-        fullName: string;
-        email: string;
-        phone?: string;
-        source?: string;
-        deviceId?: string;
-      });
+      const result = await this.service.submitSignup(
+        value as {
+          fullName: string;
+          email: string;
+          phone?: string;
+          source?: string;
+          deviceId?: string;
+        }
+      );
       const response = {
         statusCode: StatusCode.OK,
         body: JSON.stringify(result),

--- a/server/src/controllers/PublicSignupController.ts
+++ b/server/src/controllers/PublicSignupController.ts
@@ -1,0 +1,59 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
+import Joi from "joi";
+import BaseController from "./BaseController";
+import PublicSignupService from "../services/PublicSignupService";
+import { StatusCode } from "../enums/StatusCode";
+import { extractBodyFromEvent } from "../utils/utils";
+
+const signupSchema = Joi.object({
+  fullName: Joi.string().min(1).max(120).required(),
+  email: Joi.string().email().required(),
+  phone: Joi.string().optional(),
+  source: Joi.string().optional(),
+  deviceId: Joi.string().optional(),
+});
+
+export default class PublicSignupController extends BaseController<any, PublicSignupService> {
+  constructor() {
+    super(new PublicSignupService());
+  }
+
+  signup = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+    await this.beforeAction(event);
+
+    try {
+      const body = extractBodyFromEvent(event);
+      const { error, value } = signupSchema.validate(body, { abortEarly: false, stripUnknown: true });
+
+      if (error) {
+        return {
+          statusCode: StatusCode.BAD_REQUEST,
+          body: JSON.stringify({ error: "Invalid input" }),
+        };
+      }
+
+      const result = await this.service.submitSignup(value as {
+        fullName: string;
+        email: string;
+        phone?: string;
+        source?: string;
+        deviceId?: string;
+      });
+      const response = {
+        statusCode: StatusCode.OK,
+        body: JSON.stringify(result),
+      };
+
+      await this.afterAction(response);
+
+      return response;
+    } catch (err) {
+      console.error("[PublicSignupController] Failed to handle signup", err);
+
+      return {
+        statusCode: StatusCode.INTERNAL_SERVER_ERROR,
+        body: JSON.stringify({ error: "Internal server error" }),
+      };
+    }
+  };
+}

--- a/server/src/functions/leads/index.ts
+++ b/server/src/functions/leads/index.ts
@@ -1,0 +1,19 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult, Context } from "aws-lambda";
+import { handleApiCall } from "../baseHandler";
+import PublicSignupController from "../../controllers/PublicSignupController";
+import AdminLeadsController from "../../controllers/AdminLeadsController";
+
+const publicSignupController = new PublicSignupController();
+const adminLeadsController = new AdminLeadsController();
+
+const handlers = {
+  ["POST /public/signup"]: publicSignupController.signup,
+  ["GET /admin/leads"]: adminLeadsController.getLeads,
+};
+
+export const handler = async (
+  event: APIGatewayProxyEvent,
+  context: Context
+): Promise<APIGatewayProxyResult> => {
+  return handleApiCall(event, context, handlers);
+};

--- a/server/src/functions/leads/retryUnsentLeads.ts
+++ b/server/src/functions/leads/retryUnsentLeads.ts
@@ -1,0 +1,20 @@
+import { Context, ScheduledEvent } from "aws-lambda";
+import connectToDB from "../../db/connect";
+import PublicSignupService from "../../services/PublicSignupService";
+
+const service = new PublicSignupService();
+
+export const handler = async (event: ScheduledEvent, context: Context) => {
+  context.callbackWaitsForEmptyEventLoop = false;
+
+  const dbName = process.env.DB_NAME_PROD || process.env.DB_NAME_DEV;
+  if (!dbName) {
+    throw new Error("Database name is not configured");
+  }
+
+  await connectToDB(dbName);
+
+  const summary = await service.retryUnsentLeads();
+
+  return summary;
+};

--- a/server/src/interfaces/IUnsentLead.ts
+++ b/server/src/interfaces/IUnsentLead.ts
@@ -1,0 +1,14 @@
+import mongoose from "mongoose";
+
+export interface IUnsentLead {
+  _id?: mongoose.Types.ObjectId;
+  fullName: string;
+  email: string;
+  phone?: string;
+  source?: string;
+  deviceId?: string;
+  errorMessage?: string;
+  retryCount: number;
+  createdAt?: Date;
+  updatedAt?: Date;
+}

--- a/server/src/models/unsentLeadModel.ts
+++ b/server/src/models/unsentLeadModel.ts
@@ -1,0 +1,40 @@
+import { Schema, model } from "mongoose";
+import { IUnsentLead } from "../interfaces/IUnsentLead";
+
+const unsentLeadSchema = new Schema<IUnsentLead>(
+  {
+    fullName: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+    email: {
+      type: String,
+      required: true,
+      lowercase: true,
+      trim: true,
+    },
+    phone: {
+      type: String,
+    },
+    source: {
+      type: String,
+    },
+    deviceId: {
+      type: String,
+    },
+    errorMessage: {
+      type: String,
+    },
+    retryCount: {
+      type: Number,
+      default: 0,
+    },
+  },
+  {
+    timestamps: true,
+    collection: "unsentleads",
+  }
+);
+
+export const UnsentLeadModel = model<IUnsentLead>("unsentleads", unsentLeadSchema);

--- a/server/src/repositories/Leads/UnsentLeadRepository.ts
+++ b/server/src/repositories/Leads/UnsentLeadRepository.ts
@@ -1,0 +1,13 @@
+import { IUnsentLead } from "../../interfaces/IUnsentLead";
+import { UnsentLeadModel } from "../../models/unsentLeadModel";
+import { BaseRepository } from "../BaseRepository";
+
+export default class UnsentLeadRepository extends BaseRepository<IUnsentLead> {
+  constructor() {
+    super(UnsentLeadModel);
+  }
+
+  async getAllLeads() {
+    return this.model.find().lean().exec();
+  }
+}

--- a/server/src/services/AdminLeadsService.ts
+++ b/server/src/services/AdminLeadsService.ts
@@ -1,0 +1,64 @@
+import { google, sheets_v4 } from "googleapis";
+import { BaseService } from "./BaseService";
+import UnsentLeadRepository from "../repositories/Leads/UnsentLeadRepository";
+import { IUnsentLead } from "../interfaces/IUnsentLead";
+
+const READ_SCOPE = "https://www.googleapis.com/auth/spreadsheets.readonly";
+
+export interface LeadRow {
+  timestamp: string;
+  fullName: string;
+  email: string;
+  phone: string;
+  source: string;
+  deviceId: string;
+}
+
+export default class AdminLeadsService extends BaseService<IUnsentLead, UnsentLeadRepository> {
+  constructor() {
+    super(new UnsentLeadRepository(), "unsent-leads");
+  }
+
+  private buildSheetsClient(scopes: string[]): sheets_v4.Sheets {
+    const email = process.env.GCP_CLIENT_EMAIL;
+    const key = (process.env.GCP_PRIVATE_KEY || "").replace(/\\n/g, "\n");
+    const sheetId = process.env.SHEET_ID;
+
+    if (!email || !key || !sheetId) {
+      throw new Error("Missing Google Sheets configuration");
+    }
+
+    const auth = new google.auth.JWT({
+      email,
+      key,
+      scopes,
+    });
+
+    return google.sheets({ version: "v4", auth });
+  }
+
+  async getLeads(): Promise<LeadRow[]> {
+    const sheets = this.buildSheetsClient([READ_SCOPE]);
+    const spreadsheetId = process.env.SHEET_ID!;
+    const range = "Leads!A2:F";
+
+    const response = await sheets.spreadsheets.values.get({
+      spreadsheetId,
+      range,
+    });
+
+    const rows = response.data.values || [];
+    const leads = rows.map((row) => ({
+      timestamp: row[0] || "",
+      fullName: row[1] || "",
+      email: row[2] || "",
+      phone: row[3] || "",
+      source: row[4] || "",
+      deviceId: row[5] || "",
+    }));
+
+    console.log(`[AdminLeadsService] Fetched ${leads.length} leads`);
+
+    return leads;
+  }
+}

--- a/server/src/services/PublicSignupService.ts
+++ b/server/src/services/PublicSignupService.ts
@@ -117,7 +117,9 @@ export default class PublicSignupService extends BaseService<IUnsentLead, Unsent
     const sheets = this.buildSheetsClient([APPEND_SCOPE]);
 
     for (const lead of leads) {
-      const timestamp = lead.createdAt ? new Date(lead.createdAt).toISOString() : new Date().toISOString();
+      const timestamp = lead.createdAt
+        ? new Date(lead.createdAt).toISOString()
+        : new Date().toISOString();
       const row = [
         timestamp,
         lead.fullName,

--- a/server/src/services/PublicSignupService.ts
+++ b/server/src/services/PublicSignupService.ts
@@ -1,0 +1,152 @@
+import { google, sheets_v4 } from "googleapis";
+import { BaseService } from "./BaseService";
+import UnsentLeadRepository from "../repositories/Leads/UnsentLeadRepository";
+import { IUnsentLead } from "../interfaces/IUnsentLead";
+
+const APPEND_SCOPE = "https://www.googleapis.com/auth/spreadsheets";
+
+interface SignupPayload {
+  fullName: string;
+  email: string;
+  phone?: string;
+  source?: string;
+  deviceId?: string;
+}
+
+interface SignupResult {
+  ok: boolean;
+  stored?: boolean;
+}
+
+interface RetrySummary {
+  attempted: number;
+  succeeded: number;
+  failed: number;
+}
+
+export default class PublicSignupService extends BaseService<IUnsentLead, UnsentLeadRepository> {
+  constructor() {
+    super(new UnsentLeadRepository(), "unsent-leads");
+  }
+
+  private buildSheetsClient(scopes: string[]): sheets_v4.Sheets {
+    const email = process.env.GCP_CLIENT_EMAIL;
+    const key = (process.env.GCP_PRIVATE_KEY || "").replace(/\\n/g, "\n");
+    const sheetId = process.env.SHEET_ID;
+
+    if (!email || !key || !sheetId) {
+      throw new Error("Missing Google Sheets configuration");
+    }
+
+    const auth = new google.auth.JWT({
+      email,
+      key,
+      scopes,
+    });
+
+    return google.sheets({ version: "v4", auth });
+  }
+
+  private async appendRow(values: string[], sheets?: sheets_v4.Sheets): Promise<void> {
+    const sheetsClient = sheets || this.buildSheetsClient([APPEND_SCOPE]);
+    const spreadsheetId = process.env.SHEET_ID!;
+    const range = process.env.SHEET_RANGE || "Leads!A1";
+
+    await sheetsClient.spreadsheets.values.append({
+      spreadsheetId,
+      range,
+      valueInputOption: "USER_ENTERED",
+      requestBody: {
+        values: [values],
+      },
+    });
+  }
+
+  private sanitizeErrorMessage(error: unknown): string {
+    if (error instanceof Error && error.message) {
+      return error.message.slice(0, 500);
+    }
+
+    if (typeof error === "string") {
+      return error.slice(0, 500);
+    }
+
+    return "Unknown error";
+  }
+
+  async submitSignup(payload: SignupPayload): Promise<SignupResult> {
+    const timestamp = new Date().toISOString();
+    const row = [
+      timestamp,
+      payload.fullName,
+      payload.email,
+      payload.phone || "",
+      payload.source || "",
+      payload.deviceId || "",
+    ];
+
+    try {
+      await this.appendRow(row);
+      return { ok: true };
+    } catch (error) {
+      console.error("[PublicSignupService] Failed to append lead", error);
+
+      await this.repository.create({
+        ...payload,
+        retryCount: 0,
+        errorMessage: this.sanitizeErrorMessage(error),
+      });
+
+      return { ok: false, stored: true };
+    }
+  }
+
+  async retryUnsentLeads(): Promise<RetrySummary> {
+    const leads = await this.repository.getAllLeads();
+    const summary: RetrySummary = {
+      attempted: leads.length,
+      succeeded: 0,
+      failed: 0,
+    };
+
+    if (!leads.length) {
+      console.log("[PublicSignupService] No unsent leads to retry");
+      return summary;
+    }
+
+    const sheets = this.buildSheetsClient([APPEND_SCOPE]);
+
+    for (const lead of leads) {
+      const timestamp = lead.createdAt ? new Date(lead.createdAt).toISOString() : new Date().toISOString();
+      const row = [
+        timestamp,
+        lead.fullName,
+        lead.email,
+        lead.phone || "",
+        lead.source || "",
+        lead.deviceId || "",
+      ];
+
+      try {
+        await this.appendRow(row, sheets);
+        await this.repository.deleteById(lead._id!.toString());
+        summary.succeeded += 1;
+      } catch (error) {
+        summary.failed += 1;
+        await this.repository.updateById(lead._id!.toString(), {
+          update: {
+            retryCount: (lead.retryCount || 0) + 1,
+            errorMessage: this.sanitizeErrorMessage(error),
+          },
+          options: { new: true },
+        });
+      }
+    }
+
+    console.log(
+      `[PublicSignupService] Retry summary - attempted: ${summary.attempted}, succeeded: ${summary.succeeded}, failed: ${summary.failed}`
+    );
+
+    return summary;
+  }
+}


### PR DESCRIPTION
## Summary
- add a public signup flow that validates payloads, appends them to Google Sheets, and stores failed rows for retry
- expose an admin leads endpoint backed by Google Sheets and create a retry lambda for unsent leads
- introduce persistence for unsent leads together with the Google Sheets client dependency

## Testing
- not run (googleapis dependency could not be installed in the execution environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914a9acbf3c832bb55da3645e331ada)