### PR TITLE
Align leads controller with shared validation patterns

### DIFF
--- a/server/deployAllLambdas.js
+++ b/server/deployAllLambdas.js
@@ -26,6 +26,7 @@ const lambdaFunctionsMap = {
   S3Actions: { path: "S3/index.ts", envToUse: "signedUrl" },
   ProgressNotes: { path: "ProgressNote/index.ts", envToUse: "api" },
   LessonGroups: { path: "lessonGroups/index.ts", envToUse: "api" },
+  Leads: { path: "Leads/index.ts", envToUse: "otp" },
 };
 
 async function deployAllLambdas() {

--- a/server/scripts/configureApiGateway.js
+++ b/server/scripts/configureApiGateway.js
@@ -1,9 +1,7 @@
 const { execSync } = require("child_process");
 const dotenv = require("dotenv");
 dotenv.config({ path: "./.env.local" });
-const sleep=require('./utils')
-
-
+const sleep = require("./utils");
 
 const apiId = process.env.API_ID;
 const parentResourceId = process.env.PARENT_RESOURCE_ID;

--- a/server/src/controllers/LeadsController.ts
+++ b/server/src/controllers/LeadsController.ts
@@ -1,0 +1,138 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
+import BaseController from "./BaseController";
+import LeadsService from "../services/LeadsService";
+import { ILead } from "../interfaces/ILead";
+import { StatusCode } from "../enums/StatusCode";
+import { extractBodyFromEvent, extractQueryFromEvent, getRequestIp } from "../utils/utils";
+
+export default class LeadsController extends BaseController<ILead, LeadsService> {
+  constructor() {
+    super(new LeadsService());
+  }
+
+  create = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+    await this.beforeAction(event);
+
+    try {
+      const payload = extractBodyFromEvent(event);
+      const ip = getRequestIp(event);
+      const leadPayload = ip ? { ...payload, ip } : payload;
+      const lead = await this.service.createLead(leadPayload);
+      const response = this.successResponse({
+        status: StatusCode.CREATED,
+        data: lead,
+      });
+
+      await this.afterAction(response);
+
+      return response;
+    } catch (err) {
+      return this.errorResponse(err);
+    }
+  };
+
+  list = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+    await this.beforeAction(event);
+
+    try {
+      const query = extractQueryFromEvent(event);
+      const leads = await this.service.listLeads({
+        page: query.page,
+        limit: query.limit,
+      });
+
+      const response = this.successResponse({
+        status: StatusCode.OK,
+        data: leads,
+      });
+
+      await this.afterAction(response);
+
+      return response;
+    } catch (err) {
+      return this.errorResponse(err);
+    }
+  };
+
+  getById = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+    await this.beforeAction(event);
+
+    try {
+      const { id, error } = this.getParamsOrError(event, ["id"]);
+
+      if (error) return error;
+
+      const lead = await this.service.getLeadById(id);
+
+      if (!lead) {
+        return this.errorResponse("Lead not found", StatusCode.NOT_FOUND);
+      }
+
+      const response = this.successResponse({
+        status: StatusCode.OK,
+        data: lead,
+      });
+
+      await this.afterAction(response);
+
+      return response;
+    } catch (err) {
+      return this.errorResponse(err);
+    }
+  };
+
+  update = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+    await this.beforeAction(event);
+
+    try {
+      const payload = extractBodyFromEvent(event);
+      const { id, error } = this.getParamsOrError(event, ["id"]);
+
+      if (error) return error;
+
+      const updated = await this.service.updateLead(id, payload);
+
+      if (!updated) {
+        return this.errorResponse("Lead not found", StatusCode.NOT_FOUND);
+      }
+
+      const response = this.successResponse({
+        status: StatusCode.OK,
+        data: updated,
+      });
+
+      await this.afterAction(response);
+
+      return response;
+    } catch (err) {
+      return this.errorResponse(err);
+    }
+  };
+
+  remove = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+    await this.beforeAction(event);
+
+    try {
+      const { id, error } = this.getParamsOrError(event, ["id"]);
+
+      if (error) return error;
+
+      const deleted = await this.service.deleteLead(id);
+
+      if (!deleted) {
+        return this.errorResponse("Lead not found", StatusCode.NOT_FOUND);
+      }
+
+      const response: APIGatewayProxyResult = {
+        statusCode: StatusCode.NO_CONTENT,
+        body: "",
+      };
+
+      await this.afterAction(response);
+
+      return response;
+    } catch (err) {
+      return this.errorResponse(err);
+    }
+  };
+}

--- a/server/src/controllers/userController.ts
+++ b/server/src/controllers/userController.ts
@@ -8,7 +8,7 @@ import PasswordsService from "../services/PasswordsService";
 import { EmailService } from "../services/EmailService";
 import { IUser } from "../interfaces/IUser";
 import BaseController from "./BaseController";
-import { leadEmailTemplate, welcomeEmailTemplate } from "../utils/emailTemplates";
+import { welcomeEmailTemplate } from "../utils/emailTemplates";
 import AuthService from "../services/AuthService";
 
 export class UserController extends BaseController<IUser, UserService> {
@@ -203,28 +203,4 @@ export class UserController extends BaseController<IUser, UserService> {
     }
   };
 
-  saveLead = async (event: APIGatewayEvent) => {
-    try {
-      const { email, phone, name, error } = this.getParamsOrError(
-        event,
-        ["email", "name", "phone"],
-        "body"
-      );
-
-      if (error) return error;
-
-      const mailOptions = {
-        to: "noammz101@gmail.com",
-        ...leadEmailTemplate(name, phone, email),
-      };
-
-      await new EmailService().sendEmail(mailOptions);
-
-      return this.successResponse({
-        status: StatusCode.OK,
-      });
-    } catch (error) {
-      return this.errorResponse(error);
-    }
-  };
 }

--- a/server/src/controllers/userController.ts
+++ b/server/src/controllers/userController.ts
@@ -202,5 +202,4 @@ export class UserController extends BaseController<IUser, UserService> {
       return this.errorResponse(error);
     }
   };
-
 }

--- a/server/src/functions/Leads/index.ts
+++ b/server/src/functions/Leads/index.ts
@@ -1,0 +1,49 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult, Context } from "aws-lambda";
+import { handleApiCall } from "../baseHandler";
+import LeadsController from "../../controllers/LeadsController";
+import { validateCreateLead, validateUpdateLead } from "../../middleware/leadsMiddleware";
+
+const BASE_PATH = "/leads";
+
+const leadsController = new LeadsController();
+
+const leadsApiHandlers = {
+  [`POST ${BASE_PATH}`]: leadsController.create,
+  [`GET ${BASE_PATH}`]: leadsController.list,
+  [`GET ${BASE_PATH}/{id}`]: leadsController.getById,
+  [`PUT ${BASE_PATH}/{id}`]: leadsController.update,
+  [`DELETE ${BASE_PATH}/{id}`]: leadsController.remove,
+};
+
+const leadsApiValidators = {
+  [`POST ${BASE_PATH}`]: validateCreateLead,
+  [`PUT ${BASE_PATH}/{id}`]: validateUpdateLead,
+};
+
+const normalizeEventPath = (event: APIGatewayProxyEvent): APIGatewayProxyEvent => {
+  const match = event.path?.match(new RegExp(`^${BASE_PATH}/([^/]+)$`));
+
+  if (match && match[1]) {
+    const leadId = decodeURIComponent(match[1]);
+
+    return {
+      ...event,
+      path: `${BASE_PATH}/{id}`,
+      pathParameters: {
+        ...(event.pathParameters || {}),
+        id: leadId,
+      },
+    } as APIGatewayProxyEvent;
+  }
+
+  return event;
+};
+
+export const handler = async (
+  event: APIGatewayProxyEvent,
+  context: Context
+): Promise<APIGatewayProxyResult> => {
+  const normalizedEvent = normalizeEventPath(event);
+
+  return handleApiCall(normalizedEvent, context, leadsApiHandlers, leadsApiValidators);
+};

--- a/server/src/functions/Leads/index.ts
+++ b/server/src/functions/Leads/index.ts
@@ -20,30 +20,9 @@ const leadsApiValidators = {
   [`PUT ${BASE_PATH}/one`]: validateUpdateLead,
 };
 
-const normalizeEventPath = (event: APIGatewayProxyEvent): APIGatewayProxyEvent => {
-  const match = event.path?.match(new RegExp(`^${BASE_PATH}/([^/]+)$`));
-
-  if (match && match[1]) {
-    const leadId = decodeURIComponent(match[1]);
-
-    return {
-      ...event,
-      path: `${BASE_PATH}/{id}`,
-      pathParameters: {
-        ...(event.pathParameters || {}),
-        id: leadId,
-      },
-    } as APIGatewayProxyEvent;
-  }
-
-  return event;
-};
-
 export const handler = async (
   event: APIGatewayProxyEvent,
   context: Context
 ): Promise<APIGatewayProxyResult> => {
-  const normalizedEvent = normalizeEventPath(event);
-
-  return handleApiCall(normalizedEvent, context, leadsApiHandlers, leadsApiValidators);
+  return handleApiCall(event, context, leadsApiHandlers, leadsApiValidators);
 };

--- a/server/src/functions/Leads/index.ts
+++ b/server/src/functions/Leads/index.ts
@@ -10,14 +10,14 @@ const leadsController = new LeadsController();
 const leadsApiHandlers = {
   [`POST ${BASE_PATH}`]: leadsController.create,
   [`GET ${BASE_PATH}`]: leadsController.list,
-  [`GET ${BASE_PATH}/{id}`]: leadsController.getById,
-  [`PUT ${BASE_PATH}/{id}`]: leadsController.update,
-  [`DELETE ${BASE_PATH}/{id}`]: leadsController.remove,
+  [`GET ${BASE_PATH}/one`]: leadsController.getById,
+  [`PUT ${BASE_PATH}/one`]: leadsController.update,
+  [`DELETE ${BASE_PATH}/one`]: leadsController.remove,
 };
 
 const leadsApiValidators = {
   [`POST ${BASE_PATH}`]: validateCreateLead,
-  [`PUT ${BASE_PATH}/{id}`]: validateUpdateLead,
+  [`PUT ${BASE_PATH}/one`]: validateUpdateLead,
 };
 
 const normalizeEventPath = (event: APIGatewayProxyEvent): APIGatewayProxyEvent => {

--- a/server/src/functions/users/index.ts
+++ b/server/src/functions/users/index.ts
@@ -17,7 +17,6 @@ const userApiHandlers = {
   [`PUT ${BASE_PATH}/user/register`]: userController.register,
   [`POST ${BASE_PATH}/user/login`]: userController.logIn,
   [`POST ${BASE_PATH}/user/session`]: userController.checkUserSessionToken,
-  [`POST ${BASE_PATH}/user/lead`]: userController.saveLead,
 };
 
 const userValidaters = {

--- a/server/src/interfaces/ILead.ts
+++ b/server/src/interfaces/ILead.ts
@@ -1,0 +1,13 @@
+import mongoose from "mongoose";
+
+export interface ILead {
+  _id: mongoose.Types.ObjectId;
+  fullName: string;
+  email: string;
+  phone?: string;
+  deviceId?: string;
+  ip?: string;
+  registeredAt: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/server/src/middleware/leadsMiddleware.ts
+++ b/server/src/middleware/leadsMiddleware.ts
@@ -1,0 +1,11 @@
+import { APIGatewayEvent } from "aws-lambda";
+import { LeadCreateSchema, LeadUpdateSchema } from "../models/LeadsModel";
+import { validateBody } from "../utils/utils";
+
+export const validateCreateLead = (event: APIGatewayEvent) => {
+  return validateBody(event, LeadCreateSchema);
+};
+
+export const validateUpdateLead = (event: APIGatewayEvent) => {
+  return validateBody(event, LeadUpdateSchema);
+};

--- a/server/src/models/LeadsModel.ts
+++ b/server/src/models/LeadsModel.ts
@@ -1,0 +1,66 @@
+import { Schema, model } from "mongoose";
+import Joi from "joi";
+import { ILead } from "../interfaces/ILead";
+
+const leadsSchema = new Schema<ILead>(
+  {
+    fullName: {
+      type: String,
+      required: true,
+      trim: true,
+      maxlength: 120,
+    },
+    email: {
+      type: String,
+      required: true,
+      trim: true,
+      lowercase: true,
+      maxlength: 256,
+    },
+    phone: {
+      type: String,
+      trim: true,
+      maxlength: 64,
+    },
+    deviceId: {
+      type: String,
+      trim: true,
+      maxlength: 128,
+    },
+    ip: {
+      type: String,
+      trim: true,
+      maxlength: 64,
+    },
+    registeredAt: {
+      type: Date,
+      default: Date.now,
+    },
+  },
+  {
+    timestamps: true,
+  }
+);
+
+leadsSchema.index({ email: 1, createdAt: -1 });
+
+export const LeadsModel = model<ILead>("leads", leadsSchema);
+
+const leadBaseSchema = Joi.object({
+  fullName: Joi.string().trim().max(120),
+  email: Joi.string().trim().lowercase().email().max(256),
+  phone: Joi.string().trim().max(64),
+  deviceId: Joi.string().trim().max(128),
+  registeredAt: Joi.date(),
+}).prefs({ abortEarly: false, stripUnknown: true });
+
+export const LeadCreateSchema = leadBaseSchema.fork(
+  ["fullName", "email"],
+  (schema) => schema.required()
+);
+
+export const LeadUpdateSchema = leadBaseSchema
+  .min(1)
+  .messages({
+    "object.min": "Invalid payload",
+  });

--- a/server/src/models/LeadsModel.ts
+++ b/server/src/models/LeadsModel.ts
@@ -54,13 +54,10 @@ const leadBaseSchema = Joi.object({
   registeredAt: Joi.date(),
 }).prefs({ abortEarly: false, stripUnknown: true });
 
-export const LeadCreateSchema = leadBaseSchema.fork(
-  ["fullName", "email"],
-  (schema) => schema.required()
+export const LeadCreateSchema = leadBaseSchema.fork(["fullName", "email"], (schema) =>
+  schema.required()
 );
 
-export const LeadUpdateSchema = leadBaseSchema
-  .min(1)
-  .messages({
-    "object.min": "Invalid payload",
-  });
+export const LeadUpdateSchema = leadBaseSchema.min(1).messages({
+  "object.min": "Invalid payload",
+});

--- a/server/src/repositories/DietPlan/DietPlanRepository.ts
+++ b/server/src/repositories/DietPlan/DietPlanRepository.ts
@@ -12,12 +12,14 @@ export class DietPlanRepository extends BaseRepository<IDietPlan> {
   getPopulatedDietPlan = async (query: FilterQuery<IDietPlan>) => {
     let data = await this.model
       .findOne(query)
-      .select({ _id: false, __v: false })
-      .populate({ path: "meals.totalProtein.customItems", model: fullMenuItemPresets })
-      .populate({
-        path: "meals.totalCarbs.customItems",
-        model: fullMenuItemPresets,
-      });
+      .select({ __v: false })
+      .populate([
+        { path: "meals.totalProtein.customItems", model: fullMenuItemPresets },
+        { path: "meals.totalCarbs.customItems", model: fullMenuItemPresets },
+        { path: "meals.totalFats.customItems", model: fullMenuItemPresets },
+        { path: "meals.totalVeggies.customItems", model: fullMenuItemPresets },
+      ])
+      .lean();
 
     return data;
   };

--- a/server/src/repositories/LeadsRepository.ts
+++ b/server/src/repositories/LeadsRepository.ts
@@ -24,12 +24,7 @@ export default class LeadsRepository extends BaseRepository<ILead> {
     const skip = (page - 1) * limit;
 
     const [items, total] = await Promise.all([
-      this.model
-        .find()
-        .sort({ createdAt: -1 })
-        .skip(skip)
-        .limit(limit)
-        .lean(),
+      this.model.find().sort({ createdAt: -1 }).skip(skip).limit(limit).lean(),
       this.model.countDocuments(),
     ]);
 
@@ -44,17 +39,12 @@ export default class LeadsRepository extends BaseRepository<ILead> {
     return this.model.findById(id).lean();
   }
 
-  async updateById(
-    id: string,
-    update: Partial<ILead>
-  ): Promise<ILead | null> {
+  async updateById(id: string, update: Partial<ILead>): Promise<ILead | null> {
     if (!isValidObjectId(id)) {
       return null;
     }
 
-    return this.model
-      .findByIdAndUpdate(id, update, { new: true, runValidators: true })
-      .lean();
+    return this.model.findByIdAndUpdate(id, update, { new: true, runValidators: true }).lean();
   }
 
   async deleteById(id: string): Promise<boolean> {

--- a/server/src/repositories/LeadsRepository.ts
+++ b/server/src/repositories/LeadsRepository.ts
@@ -1,0 +1,69 @@
+import { isValidObjectId } from "mongoose";
+import { BaseRepository } from "./BaseRepository";
+import { ILead } from "../interfaces/ILead";
+import { LeadsModel } from "../models/LeadsModel";
+
+export default class LeadsRepository extends BaseRepository<ILead> {
+  constructor() {
+    super(LeadsModel);
+  }
+
+  async create(doc: Partial<ILead>): Promise<ILead> {
+    const created = await this.model.create(doc as ILead);
+
+    return created.toObject() as ILead;
+  }
+
+  async findPaginated({
+    page,
+    limit,
+  }: {
+    page: number;
+    limit: number;
+  }): Promise<{ items: ILead[]; total: number }> {
+    const skip = (page - 1) * limit;
+
+    const [items, total] = await Promise.all([
+      this.model
+        .find()
+        .sort({ createdAt: -1 })
+        .skip(skip)
+        .limit(limit)
+        .lean(),
+      this.model.countDocuments(),
+    ]);
+
+    return { items: (items as unknown as ILead[]) ?? [], total };
+  }
+
+  async findById(id: string): Promise<ILead | null> {
+    if (!isValidObjectId(id)) {
+      return null;
+    }
+
+    return this.model.findById(id).lean();
+  }
+
+  async updateById(
+    id: string,
+    update: Partial<ILead>
+  ): Promise<ILead | null> {
+    if (!isValidObjectId(id)) {
+      return null;
+    }
+
+    return this.model
+      .findByIdAndUpdate(id, update, { new: true, runValidators: true })
+      .lean();
+  }
+
+  async deleteById(id: string): Promise<boolean> {
+    if (!isValidObjectId(id)) {
+      return false;
+    }
+
+    const result = await this.model.findByIdAndDelete(id).lean();
+
+    return !!result;
+  }
+}

--- a/server/src/services/LeadsService.ts
+++ b/server/src/services/LeadsService.ts
@@ -1,0 +1,88 @@
+import { BaseService } from "./BaseService";
+import LeadsRepository from "../repositories/LeadsRepository";
+import { ILead } from "../interfaces/ILead";
+
+interface ListParams {
+  page?: number | string;
+  limit?: number | string;
+}
+
+export default class LeadsService extends BaseService<ILead, LeadsRepository> {
+  constructor() {
+    super(new LeadsRepository(), "leads");
+  }
+
+  async createLead(payload: Partial<ILead>): Promise<ILead> {
+    const leadPayload: Partial<ILead> = {
+      ...payload,
+      registeredAt: payload.registeredAt ? new Date(payload.registeredAt) : new Date(),
+    };
+
+    const lead = await this.repository.create(leadPayload);
+
+    this.cache.invalidateAll();
+
+    return lead;
+  }
+
+  async listLeads(params: ListParams): Promise<{
+    items: ILead[];
+    page: number;
+    limit: number;
+    total: number;
+  }> {
+    const page = Math.max(1, Number(params.page) || 1);
+    const limit = Math.max(1, Number(params.limit) || 25);
+    const cacheKey = this.generateCacheKey("list", `${page}:${limit}`);
+
+    const cached = this.cache.get(cacheKey);
+
+    if (cached) {
+      return cached;
+    }
+
+    const { items, total } = await this.repository.findPaginated({ page, limit });
+    const result = { items, page, limit, total };
+
+    this.cache.set(cacheKey, result);
+
+    return result;
+  }
+
+  async getLeadById(id: string): Promise<ILead | null> {
+    const cacheKey = this.generateCacheKey("id", id);
+    const cached = this.cache.get(cacheKey);
+
+    if (cached) {
+      return cached;
+    }
+
+    const lead = await this.repository.findById(id);
+
+    if (lead) {
+      this.cache.set(cacheKey, lead);
+    }
+
+    return lead;
+  }
+
+  async updateLead(id: string, update: Partial<ILead>): Promise<ILead | null> {
+    const updated = await this.repository.updateById(id, update);
+
+    if (updated) {
+      this.cache.invalidateAll();
+    }
+
+    return updated;
+  }
+
+  async deleteLead(id: string): Promise<boolean> {
+    const deleted = await this.repository.deleteById(id);
+
+    if (deleted) {
+      this.cache.invalidateAll();
+    }
+
+    return deleted;
+  }
+}

--- a/server/src/utils/utils.ts
+++ b/server/src/utils/utils.ts
@@ -162,3 +162,13 @@ export const getHeaderValue = (
   const lower = key.toLowerCase();
   return Object.entries(headers).find(([k]) => k.toLowerCase() === lower)?.[1];
 };
+
+export const getRequestIp = (event: APIGatewayEvent): string | undefined => {
+  const forwardedFor = getHeaderValue(event.headers || {}, "x-forwarded-for");
+
+  if (typeof forwardedFor === "string" && forwardedFor.trim()) {
+    return forwardedFor.split(",")[0].trim();
+  }
+
+  return event.requestContext?.identity?.sourceIp || undefined;
+};


### PR DESCRIPTION
## Summary
- move the leads Joi schema definitions into the model and export create/update variants
- add middleware-backed validation for leads create and update routes and register it with the lambda handler
- thin the leads controller by using shared helpers for params and ip extraction

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914c0c7e13c832ba0e562070106c688)