### PR TITLE
Add exerciseId sidecar mapping and canonical-key writes for recorded sets

### DIFF
--- a/server/src/controllers/recordedSetsController.ts
+++ b/server/src/controllers/recordedSetsController.ts
@@ -13,11 +13,15 @@ class RecordedSetsController extends BaseController<IMuscleGroupRecordedSets, Re
 
   addRecordedSet = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
     const { sessionId } = extractQueryFromEvent(event);
-    const { error, userId, muscleGroup, exercise, recordedSets } = this.getParamsOrError(
-      event,
-      ["userId", "muscleGroup", "exercise", "recordedSets"],
-      "body"
-    );
+    const allowLegacy = process.env.ALLOW_LEGACY_EXERCISE_NAME_ONLY === "true";
+    const isProd = event.requestContext?.stage === "prod" || process.env.STAGE === "prod";
+    const requiresExerciseId = isProd && !allowLegacy;
+    const requiredParams = ["userId", "muscleGroup", "exercise", "recordedSets"];
+    if (requiresExerciseId) {
+      requiredParams.push("exerciseId");
+    }
+    const { error, userId, muscleGroup, exercise, exerciseId, recordedSets } =
+      this.getParamsOrError(event, requiredParams, "body");
 
     if (error) return error;
     const sets = Array.isArray(recordedSets) ? recordedSets : [recordedSets];
@@ -27,6 +31,7 @@ class RecordedSetsController extends BaseController<IMuscleGroupRecordedSets, Re
         userId,
         muscleGroup,
         exercise,
+        exerciseId ?? null,
         sessionId,
         sets
       );

--- a/server/src/interfaces/ISet.ts
+++ b/server/src/interfaces/ISet.ts
@@ -23,4 +23,5 @@ export interface IMuscleGroupRecordedSets {
   userId: ObjectId;
   muscleGroup: string;
   recordedSets: IExerciseRecordedSets;
+  exerciseKeyToId?: Record<string, string>;
 }

--- a/server/src/middleware/recordedSetMiddleware.ts
+++ b/server/src/middleware/recordedSetMiddleware.ts
@@ -2,11 +2,17 @@ import Joi from "joi";
 import { RecordedSetJoiSchema } from "../models/recordedSetsModel";
 import { createValidatorResponse, extractBodyFromEvent, removeNestedIds } from "../utils/utils";
 import { APIGatewayEvent } from "aws-lambda";
+import mongoose from "mongoose";
 
 export const validateRecordedSet = (event: APIGatewayEvent) => {
-  const { userId, muscleGroup, exercise, recordedSets } = extractBodyFromEvent(event);
+  const { userId, muscleGroup, exercise, exerciseId, recordedSets } = extractBodyFromEvent(event);
   const data = removeNestedIds(recordedSets);
   let message = "";
+  const allowLegacy = process.env.ALLOW_LEGACY_EXERCISE_NAME_ONLY === "true";
+  const isProd = event.requestContext?.stage === "prod" || process.env.STAGE === "prod";
+  const requiresExerciseId = isProd && !allowLegacy;
+  const hasValidExerciseId =
+    typeof exerciseId === "string" && mongoose.Types.ObjectId.isValid(exerciseId);
 
   if (!userId) {
     message = "userId is required";
@@ -16,8 +22,24 @@ export const validateRecordedSet = (event: APIGatewayEvent) => {
     message = "exercise is required";
   }
 
+  if (requiresExerciseId && !hasValidExerciseId) {
+    message = "exerciseId is required";
+  }
+
   if (message) {
     return createValidatorResponse(false, message);
+  }
+
+  if (!requiresExerciseId && !hasValidExerciseId) {
+    console.warn({
+      service: "RecordedSetMiddleware.validateRecordedSet",
+      message: "Missing or invalid exerciseId; allowing legacy exercise key",
+      userId,
+      muscleGroup,
+      exercise,
+      stage: event.requestContext?.stage,
+      timestamp: new Date().toISOString(),
+    });
   }
 
   const sets = Array.isArray(data) ? data : [data];

--- a/server/src/models/recordedSetsModel.ts
+++ b/server/src/models/recordedSetsModel.ts
@@ -23,6 +23,7 @@ const muscleGroupRecordedSetsSchema = new Schema<IMuscleGroupRecordedSetsDocumen
   userId: { type: Schema.Types.ObjectId, ref: "User", required: true },
   muscleGroup: { type: String, required: true },
   recordedSets: { type: Object, of: [exerciseRecordedSetsSchema], default: {} },
+  exerciseKeyToId: { type: Object, default: {} },
 });
 
 export const RecordedSet = model<IRecordedSet>("RecordedSet", recordedSetSchema);
@@ -42,6 +43,7 @@ const muscleGroupRecordedSetsJoiSchema = Joi.object<IMuscleGroupRecordedSets>({
   userId: Joi.string().required(),
   muscleGroup: Joi.string().required(),
   recordedSets: Joi.object().pattern(Joi.string(), Joi.array().items(RecordedSetJoiSchema)),
+  exerciseKeyToId: Joi.object().pattern(Joi.string(), Joi.string()),
 });
 
 export { RecordedSetJoiSchema, muscleGroupRecordedSetsJoiSchema };

--- a/server/src/repositories/BaseRepository.ts
+++ b/server/src/repositories/BaseRepository.ts
@@ -72,8 +72,7 @@ export class BaseRepository<T> {
   }: PaginationParams): Promise<PaginationResult<T>> {
     const skip = (page - 1) * limit;
     const queryHasKeys = !!Object.keys(query).length;
-    const parsedQuery =
-      queryHasKeys && typeof query === "string" ? JSON.parse(query) : query;
+    const parsedQuery = queryHasKeys && typeof query === "string" ? JSON.parse(query) : query;
 
     const [results, totalResults] = await Promise.all([
       this.model.find(parsedQuery).sort(sort).skip(skip).limit(limit),

--- a/server/src/repositories/BaseRepository.ts
+++ b/server/src/repositories/BaseRepository.ts
@@ -72,7 +72,8 @@ export class BaseRepository<T> {
   }: PaginationParams): Promise<PaginationResult<T>> {
     const skip = (page - 1) * limit;
     const queryHasKeys = !!Object.keys(query).length;
-    const parsedQuery = queryHasKeys ? JSON.parse(query) : {};
+    const parsedQuery =
+      queryHasKeys && typeof query === "string" ? JSON.parse(query) : query;
 
     const [results, totalResults] = await Promise.all([
       this.model.find(parsedQuery).sort(sort).skip(skip).limit(limit),

--- a/server/src/services/BaseService.ts
+++ b/server/src/services/BaseService.ts
@@ -1,0 +1,1 @@
+export { BaseService } from "./baseService";

--- a/server/src/services/recordedSetsService.ts
+++ b/server/src/services/recordedSetsService.ts
@@ -22,7 +22,7 @@ export class RecordedSetsService extends BaseService<
 
   private buildSessionDetails(
     userId: string,
-    exercise: string,
+    exerciseKey: string,
     nextSetNumber: number,
     recordedSet: IRecordedSet,
     activeSession: ISession | null = null
@@ -35,17 +35,42 @@ export class RecordedSetsService extends BaseService<
       type: "workout",
       data: {
         ...activeSession?.data,
-        [plan]: { ...existingPlanData, [exercise]: { setNumber: nextSetNumber } },
+        [plan]: { ...existingPlanData, [exerciseKey]: { setNumber: nextSetNumber } },
       },
     };
 
     return sessionDetails;
   }
 
+  private async getCanonicalExerciseName(exerciseId: string): Promise<string | null> {
+    if (!mongoose.Types.ObjectId.isValid(exerciseId)) {
+      return null;
+    }
+
+    const db = mongoose.connection?.db;
+    if (!db) {
+      return null;
+    }
+
+    try {
+      const exerciseDoc = await db.collection("exercises").findOne(
+        { _id: new mongoose.Types.ObjectId(exerciseId) },
+        {
+          projection: { name: 1 },
+        }
+      );
+
+      return exerciseDoc?.name ?? null;
+    } catch (error) {
+      return null;
+    }
+  }
+
   async addRecordedSets(
     userId: string,
     muscleGroup: string,
     exercise: string,
+    exerciseId: string | null,
     sessionId: string | null,
     recordedSets: IRecordedSet[]
   ) {
@@ -57,8 +82,33 @@ export class RecordedSetsService extends BaseService<
       const activeSession = sessionId ? await this.sessionService.getSessionById(sessionId) : null;
       const isNewSession = activeSession == null;
 
+      const incomingExerciseKey = exercise;
+      const canonicalExerciseName = exerciseId
+        ? await this.getCanonicalExerciseName(exerciseId)
+        : null;
+      const canonicalKey = canonicalExerciseName ?? incomingExerciseKey;
+
+      if (canonicalExerciseName && canonicalExerciseName !== incomingExerciseKey) {
+        console.warn({
+          service: "RecordedSetsService.addRecordedSets",
+          userId,
+          muscleGroup,
+          exerciseId,
+          receivedExerciseKey: incomingExerciseKey,
+          canonicalExerciseName,
+          sessionId,
+          timestamp: new Date().toISOString(),
+        });
+      }
+
       const muscleGroupRecord = await this.repository.findOrCreate(objectId, muscleGroup);
-      this.repository.initializeExerciseIfNecessary(muscleGroupRecord, exercise);
+      this.repository.initializeExerciseIfNecessary(muscleGroupRecord, canonicalKey);
+      if (exerciseId && mongoose.Types.ObjectId.isValid(exerciseId)) {
+        muscleGroupRecord.exerciseKeyToId = muscleGroupRecord.exerciseKeyToId ?? {};
+        muscleGroupRecord.exerciseKeyToId[incomingExerciseKey] = exerciseId;
+        muscleGroupRecord.exerciseKeyToId[canonicalKey] = exerciseId;
+        muscleGroupRecord.markModified("exerciseKeyToId");
+      }
       await muscleGroupRecord.save();
 
       const lastIndex = recordedSets.length - 1;
@@ -75,14 +125,14 @@ export class RecordedSetsService extends BaseService<
       const appendResult = await this.repository.appendRecordedSetsById(
         objectId,
         muscleGroup,
-        exercise,
+        canonicalKey,
         normalizedSets
       );
 
       const last = normalizedSets[normalizedSets.length - 1];
       const sessionDetails: ISessionCreate = this.buildSessionDetails(
         userId,
-        exercise,
+        canonicalKey,
         nextSetNumber,
         last,
         activeSession
@@ -109,10 +159,13 @@ export class RecordedSetsService extends BaseService<
     userId: string,
     muscleGroup: string,
     exercise: string,
+    exerciseId: string | null,
     sessionId: string,
     recordedSet: IRecordedSet
   ) {
-    return this.addRecordedSets(userId, muscleGroup, exercise, sessionId, [recordedSet]);
+    return this.addRecordedSets(userId, muscleGroup, exercise, exerciseId, sessionId, [
+      recordedSet,
+    ]);
   }
 
   async updateRecordedSetById(setId: string, userId: string, exercise: string, set: IRecordedSet) {
@@ -156,7 +209,7 @@ export class RecordedSetsService extends BaseService<
     try {
       const result = await this.repository.findOne({
         query: { userId, muscleGroup },
-        projection: { [`recordedSets.${exercise}`]: 1 },
+        projection: { [`recordedSets.${exercise}`]: 1 } as Record<string, 1>,
       });
 
       const sets = result?.recordedSets?.[exercise];

--- a/server/src/utils/pagination.ts
+++ b/server/src/utils/pagination.ts
@@ -3,7 +3,7 @@ import { stableStringify } from "./utils";
 export interface PaginationParams {
   limit: number;
   page: number;
-  query?: Record<string, any>;
+  query?: Record<string, any> | string;
   sort?: Record<string, 1 | -1>;
 }
 

--- a/server/tests/middleware/recordedSetMiddleware.test.ts
+++ b/server/tests/middleware/recordedSetMiddleware.test.ts
@@ -1,0 +1,29 @@
+import { APIGatewayEvent } from "aws-lambda";
+import { validateRecordedSet } from "../../src/middleware/recordedSetMiddleware";
+
+describe("recordedSetMiddleware", () => {
+  const baseBody = {
+    userId: "user-1",
+    muscleGroup: "Chest",
+    exercise: "Old Name",
+    recordedSets: {
+      plan: "Plan A",
+      weight: 100,
+      repsDone: 8,
+      note: "",
+      date: new Date(),
+    },
+  };
+
+  test("requires exerciseId in prod", () => {
+    const event = {
+      body: JSON.stringify(baseBody),
+      requestContext: { stage: "prod" },
+    } as APIGatewayEvent;
+
+    const result = validateRecordedSet(event);
+
+    expect(result.isValid).toBe(false);
+    expect(result.message).toBe("exerciseId is required");
+  });
+});

--- a/server/tests/services/recordedSetsService.test.ts
+++ b/server/tests/services/recordedSetsService.test.ts
@@ -1,0 +1,80 @@
+import mongoose from "mongoose";
+import { RecordedSetsService } from "../../src/services/recordedSetsService";
+import { MuscleGroupRecordedSets } from "../../src/models/recordedSetsModel";
+
+describe("RecordedSetsService", () => {
+  test("writes exerciseKeyToId and canonical key", async () => {
+    const service = new RecordedSetsService();
+    const userId = new mongoose.Types.ObjectId().toHexString();
+    const exerciseId = new mongoose.Types.ObjectId();
+    const db = mongoose.connection.db;
+    if (!db) {
+      throw new Error("Database connection not initialized");
+    }
+    await db.collection("exercises").insertOne({
+      _id: exerciseId,
+      name: "Bench Press",
+    });
+
+    await service.addRecordedSets(userId, "Chest", "Old Name", exerciseId.toHexString(), null, [
+      {
+        plan: "Plan A",
+        exercise: "Old Name",
+        setNumber: 1,
+        weight: 100,
+        repsDone: 8,
+        note: "",
+        date: new Date(),
+      },
+    ]);
+
+    const record = await MuscleGroupRecordedSets.findOne({ userId, muscleGroup: "Chest" }).lean();
+
+    expect(record?.recordedSets?.["Bench Press"]).toHaveLength(1);
+    expect(record?.exerciseKeyToId?.["Old Name"]).toBe(exerciseId.toHexString());
+    expect(record?.exerciseKeyToId?.["Bench Press"]).toBe(exerciseId.toHexString());
+  });
+
+  test("logs warning on mismatched canonical exercise name", async () => {
+    const service = new RecordedSetsService();
+    const userId = new mongoose.Types.ObjectId().toHexString();
+    const exerciseId = new mongoose.Types.ObjectId();
+    const db = mongoose.connection.db;
+    if (!db) {
+      throw new Error("Database connection not initialized");
+    }
+    await db.collection("exercises").insertOne({
+      _id: exerciseId,
+      name: "Bench Press",
+    });
+
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    await service.addRecordedSets(userId, "Chest", "Old Name", exerciseId.toHexString(), null, [
+      {
+        plan: "Plan A",
+        exercise: "Old Name",
+        setNumber: 1,
+        weight: 100,
+        repsDone: 8,
+        note: "",
+        date: new Date(),
+      },
+    ]);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        service: "RecordedSetsService.addRecordedSets",
+        userId,
+        muscleGroup: "Chest",
+        exerciseId: exerciseId.toHexString(),
+        receivedExerciseKey: "Old Name",
+        canonicalExerciseName: "Bench Press",
+        sessionId: null,
+        timestamp: expect.any(String),
+      })
+    );
+
+    warnSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
### Motivation
- Recorded sets were keyed by mutable human-readable `exercise` names which caused history to split when trainers renamed exercises.  
- We must stop future splits by anchoring identity to `exerciseId` while preserving existing response shapes.  
- Allow legacy clients during rollout but require `exerciseId` in production to enforce correct identity.  
- Provide lightweight sidecar mapping to record which string keys map to which canonical `exerciseId` without migrating historic buckets.

### Description
- Require/validate and forward `exerciseId` from controller: `RecordedSetsController.addRecordedSet` now requires `exerciseId` in prod and forwards it to the service.  
- Add canonical lookup + normalization + warning in service: `RecordedSetsService` gets `exerciseId`, looks up canonical name from the `exercises` collection, logs a structured warning when incoming key differs, and uses the canonical name as the write key for new writes.  
- Store a sidecar mapping on documents: added `exerciseKeyToId` to the `MuscleGroupRecordedSets` schema and Joi schema and persist `exerciseKeyToId[incomingKey]` and `exerciseKeyToId[canonicalKey]` => `exerciseId`.  
- Validation and compatibility: `validateRecordedSet` middleware now enforces `exerciseId` in prod (or allows legacy when `ALLOW_LEGACY_EXERCISE_NAME_ONLY=true`), and warns when missing in non-prod; minimal type fixes (`pagination` typing, projection cast) and added `BaseService` re-export to satisfy imports.  
- Tests: added Jest tests asserting prod validation enforcement and that the service writes `exerciseKeyToId` and uses canonical key and emits the mismatch warning.

### Testing
- Added unit tests under `tests/middleware/recordedSetMiddleware.test.ts` and `tests/services/recordedSetsService.test.ts` covering `exerciseId` requirement and canonical-key write + mapping and warning behavior.  
- Ran `npm test -- recordedSets` to execute the new tests.  
- Tests did not complete successfully: the test run failed during startup with a TypeScript error in an unrelated module (`src/utils/meals.ts`), so the new tests were not able to finish running.
- No runtime data migrations or breaking changes to response shapes were introduced; runtime behavior falls back to legacy key handling outside prod per the rollout guardrail.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695588e1e5d0832b9e4c2c3b1713dbb5)