### PR TITLE
Add optional exerciseId to recorded sets (schema, validation, controller, service)

### DIFF
--- a/server/src/controllers/recordedSetsController.ts
+++ b/server/src/controllers/recordedSetsController.ts
@@ -2,7 +2,7 @@ import { APIGatewayEvent, APIGatewayProxyEvent, APIGatewayProxyResult } from "aw
 import { RecordedSetsService } from "../services/recordedSetsService";
 import { StatusCode } from "../enums/StatusCode";
 import mongoose from "mongoose";
-import { createResponse, extractQueryFromEvent } from "../utils/utils";
+import { createResponse, extractBodyFromEvent, extractQueryFromEvent } from "../utils/utils";
 import BaseController from "./BaseController";
 import { IMuscleGroupRecordedSets } from "../interfaces/ISet";
 
@@ -13,6 +13,7 @@ class RecordedSetsController extends BaseController<IMuscleGroupRecordedSets, Re
 
   addRecordedSet = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
     const { sessionId } = extractQueryFromEvent(event);
+    const { exerciseId } = extractBodyFromEvent(event);
     const { error, userId, muscleGroup, exercise, recordedSets } = this.getParamsOrError(
       event,
       ["userId", "muscleGroup", "exercise", "recordedSets"],
@@ -28,7 +29,8 @@ class RecordedSetsController extends BaseController<IMuscleGroupRecordedSets, Re
         muscleGroup,
         exercise,
         sessionId,
-        sets
+        sets,
+        exerciseId
       );
 
       return {

--- a/server/src/interfaces/ISet.ts
+++ b/server/src/interfaces/ISet.ts
@@ -8,6 +8,7 @@ export interface ISet {
 export interface IRecordedSet {
   plan: string;
   exercise: string;
+  exerciseId?: ObjectId;
   setNumber: number;
   weight: number;
   repsDone: number;

--- a/server/src/middleware/recordedSetMiddleware.ts
+++ b/server/src/middleware/recordedSetMiddleware.ts
@@ -2,9 +2,10 @@ import Joi from "joi";
 import { RecordedSetJoiSchema } from "../models/recordedSetsModel";
 import { createValidatorResponse, extractBodyFromEvent, removeNestedIds } from "../utils/utils";
 import { APIGatewayEvent } from "aws-lambda";
+import mongoose from "mongoose";
 
 export const validateRecordedSet = (event: APIGatewayEvent) => {
-  const { userId, muscleGroup, exercise, recordedSets } = extractBodyFromEvent(event);
+  const { userId, muscleGroup, exercise, recordedSets, exerciseId } = extractBodyFromEvent(event);
   const data = removeNestedIds(recordedSets);
   let message = "";
 
@@ -18,6 +19,10 @@ export const validateRecordedSet = (event: APIGatewayEvent) => {
 
   if (message) {
     return createValidatorResponse(false, message);
+  }
+
+  if (exerciseId && !mongoose.isValidObjectId(exerciseId)) {
+    return createValidatorResponse(false, "exerciseId is invalid");
   }
 
   const sets = Array.isArray(data) ? data : [data];

--- a/server/src/models/recordedSetsModel.ts
+++ b/server/src/models/recordedSetsModel.ts
@@ -11,6 +11,7 @@ const recordedSetSchema = new Schema<IRecordedSet>({
   weight: { type: Number, min: 1, required: true },
   repsDone: { type: Number, min: 1, required: true },
   note: { type: String },
+  exerciseId: { type: Schema.Types.ObjectId, required: false },
   date: { type: Date, default: Date.now },
 });
 
@@ -35,6 +36,7 @@ const RecordedSetJoiSchema = Joi.object<IRecordedSet>({
   weight: Joi.number().min(1).required(),
   repsDone: Joi.number().min(1).required(),
   note: Joi.string().allow(null, ""),
+  exerciseId: Joi.string().optional().allow(null, ""),
   date: Joi.date().default(() => new Date()),
 });
 

--- a/server/src/services/recordedSetsService.ts
+++ b/server/src/services/recordedSetsService.ts
@@ -47,12 +47,17 @@ export class RecordedSetsService extends BaseService<
     muscleGroup: string,
     exercise: string,
     sessionId: string | null,
-    recordedSets: IRecordedSet[]
+    recordedSets: IRecordedSet[],
+    exerciseId?: string
   ) {
     try {
       if (!recordedSets?.length) {
         throw new Error("No recorded sets provided");
       }
+      const exerciseObjectId =
+        exerciseId && mongoose.isValidObjectId(exerciseId)
+          ? new mongoose.mongo.ObjectId(exerciseId)
+          : null;
       const objectId = new mongoose.mongo.ObjectId(userId);
       const activeSession = sessionId ? await this.sessionService.getSessionById(sessionId) : null;
       const isNewSession = activeSession == null;
@@ -69,6 +74,7 @@ export class RecordedSetsService extends BaseService<
           new RecordedSet({
             ...s,
             setNumber: s.setNumber ?? nextSetNumber + i,
+            ...(exerciseObjectId ? { exerciseId: exerciseObjectId } : {}),
           })
       );
 
@@ -110,9 +116,10 @@ export class RecordedSetsService extends BaseService<
     muscleGroup: string,
     exercise: string,
     sessionId: string,
-    recordedSet: IRecordedSet
+    recordedSet: IRecordedSet,
+    exerciseId?: string
   ) {
-    return this.addRecordedSets(userId, muscleGroup, exercise, sessionId, [recordedSet]);
+    return this.addRecordedSets(userId, muscleGroup, exercise, sessionId, [recordedSet], exerciseId);
   }
 
   async updateRecordedSetById(setId: string, userId: string, exercise: string, set: IRecordedSet) {

--- a/server/src/services/recordedSetsService.ts
+++ b/server/src/services/recordedSetsService.ts
@@ -54,7 +54,7 @@ export class RecordedSetsService extends BaseService<
       if (!recordedSets?.length) {
         throw new Error("No recorded sets provided");
       }
-      
+
       const exerciseObjectId =
         exerciseId && mongoose.isValidObjectId(exerciseId)
           ? new mongoose.mongo.ObjectId(exerciseId)
@@ -66,7 +66,7 @@ export class RecordedSetsService extends BaseService<
       const muscleGroupRecord = await this.repository.findOrCreate(objectId, muscleGroup);
       this.repository.initializeExerciseIfNecessary(muscleGroupRecord, exercise);
       await muscleGroupRecord.save();
-      
+
       const lastIndex = recordedSets.length - 1;
       const nextSetNumber = recordedSets[lastIndex]?.setNumber + 1;
 

--- a/server/src/services/recordedSetsService.ts
+++ b/server/src/services/recordedSetsService.ts
@@ -119,7 +119,14 @@ export class RecordedSetsService extends BaseService<
     recordedSet: IRecordedSet,
     exerciseId?: string
   ) {
-    return this.addRecordedSets(userId, muscleGroup, exercise, sessionId, [recordedSet], exerciseId);
+    return this.addRecordedSets(
+      userId,
+      muscleGroup,
+      exercise,
+      sessionId,
+      [recordedSet],
+      exerciseId
+    );
   }
 
   async updateRecordedSetById(setId: string, userId: string, exercise: string, set: IRecordedSet) {


### PR DESCRIPTION
### Motivation
- The mobile app will send `exerciseId` when recording sets and the server must store it when provided without breaking existing clients.
- `exerciseId` must be optional and backwards-compatible so legacy clients continue to work and existing storage shape is unchanged.
- Validation must reject only invalid `exerciseId` values but allow missing or null values.
- No changes to read logic, repository behavior, sessions, cache, or collection shape beyond adding optional metadata to new records.

### Description
- Updated `src/models/recordedSetsModel.ts` to add an optional `exerciseId` field to the Mongoose `recordedSetSchema` and to include `exerciseId` in `RecordedSetJoiSchema` as `Joi.string().optional().allow(null, "")`.
- Added `exerciseId?: ObjectId` to the `IRecordedSet` interface in `src/interfaces/ISet.ts` to represent optional metadata.
- Enhanced `src/middleware/recordedSetMiddleware.ts` to read `exerciseId` from the request body and return a validator error `"exerciseId is invalid"` when `mongoose.isValidObjectId(exerciseId)` is false, while allowing missing values.
- Modified `src/controllers/recordedSetsController.ts` to extract `exerciseId` from the body and pass it to the service, and updated `src/services/recordedSetsService.ts` so `addRecordedSets` accepts an optional `exerciseId`, converts it to a `ObjectId` when valid, and includes it on new `RecordedSet` instances while leaving all other logic unchanged.

### Testing
- No automated tests were executed as part of this change.
- TypeScript types were updated to reflect the optional field and service/controller signatures were adjusted accordingly.
- Manual review confirms only optional metadata was added and no required parameters or storage shape changes were made.
- Commit created with message `Add optional exerciseId to recorded sets`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955a9812c24832b8777b0fdbbfd5fe9)