### PR TITLE
JWT auth foundation: access tokens, refresh sessions, /auth endpoints, docs & tests

### DIFF
--- a/server/docs/auth-jwt-implementation.md
+++ b/server/docs/auth-jwt-implementation.md
@@ -1,7 +1,9 @@
 # Auth JWT Implementation
 
 ## Overview
+
 Implemented foundational authentication hardening for a future multi-tenant platform:
+
 - Added JWT-style short-lived access tokens with minimal identity claims (`userId`, `role`, optional `sessionId`).
 - Added refresh-token session creation, validation, and revocation using hashed opaque refresh tokens.
 - Added `/auth/login`, `/auth/refresh`, `/auth/logout`, `/auth/me` routes (wired through existing users lambda handler).
@@ -9,9 +11,11 @@ Implemented foundational authentication hardening for a future multi-tenant plat
 - Added safe user projection and status-aware checks (`hasAccess`, invite/onboarding gate).
 
 Out of scope and intentionally not implemented:
+
 - Full RBAC/permissions system, trainer scoping, ownership checks, plan limits, and asset authorization.
 
 ## Auth Flow
+
 1. **Login (`POST /auth/login`)**
    - Validate credentials via existing `AuthService` and `PasswordsService`.
    - Create short-lived access token.
@@ -31,31 +35,38 @@ Out of scope and intentionally not implemented:
    - Return safe user shape only.
 
 ## Endpoints
+
 - `POST /auth/login`: logs user in and returns `{ accessToken, refreshToken, sessionId, user }`.
 - `POST /auth/refresh`: returns `{ accessToken, user }` after refresh validation.
 - `POST /auth/logout`: revokes refresh token session.
 - `GET /auth/me`: returns safe user profile for valid access token.
 
 ## Middleware
+
 No standalone `requireAuth`/`requireRole` middleware module was introduced yet; equivalent logic is currently applied inside `/auth/me` flow via token extraction + verification + DB user lookup. This is a known follow-up task.
 
 ## Token Design
+
 - Access tokens: HMAC-signed JWT-compatible format (header.payload.signature) with `exp` claim and minimal identity claims.
 - Refresh strategy: opaque random token, hashed via SHA-256 before persistence.
 - Secrets: `JWT_ACCESS_SECRET`.
 - Authorization truth remains DB-backed (user existence/status checked on authenticated flows).
 
 ## Environment Variables
+
 - `JWT_ACCESS_SECRET` (required): HMAC secret for access token signing.
 - `JWT_ACCESS_EXPIRES_IN` (optional, default `15m`): access token TTL (supports `m/h/d` or seconds).
 - `JWT_REFRESH_EXPIRES_IN_MS` (optional, default 30 days in ms): refresh session TTL.
 
 ## User Status Rules
+
 Current implementation maps:
+
 - `hasAccess=false` => blocked for login/refresh/me.
 - `onboardingStep!==completed` => blocked on normal login (pending invite equivalent gate).
 
 ## Security Decisions
+
 - Generic invalid credential messaging for unknown user/wrong password.
 - Password verification stays in `PasswordsService` using bcrypt.
 - Safe user projection strips sensitive fields.
@@ -63,19 +74,24 @@ Current implementation maps:
 - Password hashes/token hashes are never returned in auth responses.
 
 ## Tests
+
 Added unit tests for:
+
 - access token signing/verification
 - malformed token rejection
 - expired token rejection
 - refresh token hashing determinism
 
 ## Future Extension Notes
+
 Next steps should add reusable middleware modules:
+
 - `requireAuth`
 - `requireRole`
 - then extension to `requirePermission`, `requireTrainerScope`, `requireResourceOwnership`, and plan checks.
 
 ## Follow-up Work
+
 - Add first-class `status` field (`active/inactive/suspended/pending_invite`) on user model.
 - Implement refresh rotation (not only validation + revoke).
 - Add comprehensive integration tests covering endpoint-level login/refresh/logout/me scenarios.

--- a/server/docs/auth-jwt-implementation.md
+++ b/server/docs/auth-jwt-implementation.md
@@ -1,0 +1,81 @@
+# Auth JWT Implementation
+
+## Overview
+Implemented foundational authentication hardening for a future multi-tenant platform:
+- Added JWT-style short-lived access tokens with minimal identity claims (`userId`, `role`, optional `sessionId`).
+- Added refresh-token session creation, validation, and revocation using hashed opaque refresh tokens.
+- Added `/auth/login`, `/auth/refresh`, `/auth/logout`, `/auth/me` routes (wired through existing users lambda handler).
+- Hardened login to normalize emails and return generic invalid-credentials errors.
+- Added safe user projection and status-aware checks (`hasAccess`, invite/onboarding gate).
+
+Out of scope and intentionally not implemented:
+- Full RBAC/permissions system, trainer scoping, ownership checks, plan limits, and asset authorization.
+
+## Auth Flow
+1. **Login (`POST /auth/login`)**
+   - Validate credentials via existing `AuthService` and `PasswordsService`.
+   - Create short-lived access token.
+   - Create hashed refresh session (`type: auth_refresh`) with expiry/revocation metadata.
+2. **Access token usage**
+   - Bearer token sent in `Authorization`.
+   - Verified signature + expiration.
+   - User loaded from DB in `/auth/me` for status/source-of-truth checks.
+3. **Refresh (`POST /auth/refresh`)**
+   - Refresh token hashed and looked up in DB.
+   - Reject invalid/revoked/expired token or inactive/missing user.
+   - Return fresh access token.
+4. **Logout (`POST /auth/logout`)**
+   - Revoke refresh session in DB (`revokedAt`).
+5. **Current user (`GET /auth/me`)**
+   - Verify access token and load current user from DB.
+   - Return safe user shape only.
+
+## Endpoints
+- `POST /auth/login`: logs user in and returns `{ accessToken, refreshToken, sessionId, user }`.
+- `POST /auth/refresh`: returns `{ accessToken, user }` after refresh validation.
+- `POST /auth/logout`: revokes refresh token session.
+- `GET /auth/me`: returns safe user profile for valid access token.
+
+## Middleware
+No standalone `requireAuth`/`requireRole` middleware module was introduced yet; equivalent logic is currently applied inside `/auth/me` flow via token extraction + verification + DB user lookup. This is a known follow-up task.
+
+## Token Design
+- Access tokens: HMAC-signed JWT-compatible format (header.payload.signature) with `exp` claim and minimal identity claims.
+- Refresh strategy: opaque random token, hashed via SHA-256 before persistence.
+- Secrets: `JWT_ACCESS_SECRET`.
+- Authorization truth remains DB-backed (user existence/status checked on authenticated flows).
+
+## Environment Variables
+- `JWT_ACCESS_SECRET` (required): HMAC secret for access token signing.
+- `JWT_ACCESS_EXPIRES_IN` (optional, default `15m`): access token TTL (supports `m/h/d` or seconds).
+- `JWT_REFRESH_EXPIRES_IN_MS` (optional, default 30 days in ms): refresh session TTL.
+
+## User Status Rules
+Current implementation maps:
+- `hasAccess=false` => blocked for login/refresh/me.
+- `onboardingStep!==completed` => blocked on normal login (pending invite equivalent gate).
+
+## Security Decisions
+- Generic invalid credential messaging for unknown user/wrong password.
+- Password verification stays in `PasswordsService` using bcrypt.
+- Safe user projection strips sensitive fields.
+- Refresh token revocation persisted in DB.
+- Password hashes/token hashes are never returned in auth responses.
+
+## Tests
+Added unit tests for:
+- access token signing/verification
+- malformed token rejection
+- expired token rejection
+- refresh token hashing determinism
+
+## Future Extension Notes
+Next steps should add reusable middleware modules:
+- `requireAuth`
+- `requireRole`
+- then extension to `requirePermission`, `requireTrainerScope`, `requireResourceOwnership`, and plan checks.
+
+## Follow-up Work
+- Add first-class `status` field (`active/inactive/suspended/pending_invite`) on user model.
+- Implement refresh rotation (not only validation + revoke).
+- Add comprehensive integration tests covering endpoint-level login/refresh/logout/me scenarios.

--- a/server/src/controllers/userController.ts
+++ b/server/src/controllers/userController.ts
@@ -180,15 +180,20 @@ export class UserController extends BaseController<IUser, UserService> {
     }
   };
 
-
   refreshAuth = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
     const { refreshToken, error } = this.getParamsOrError(event, ["refreshToken"], "body");
     if (error) return error;
 
     try {
       const { user } = await this.jwtAuthService.validateRefreshToken(refreshToken);
-      const accessToken = this.jwtAuthService.signAccessToken({ userId: user._id.toString(), role: user.role });
-      return this.successResponse({ status: StatusCode.OK, data: { accessToken, user: this.toSafeUser(user) } });
+      const accessToken = this.jwtAuthService.signAccessToken({
+        userId: user._id.toString(),
+        role: user.role,
+      });
+      return this.successResponse({
+        status: StatusCode.OK,
+        data: { accessToken, user: this.toSafeUser(user) },
+      });
     } catch (err: any) {
       return this.errorResponse(err.message, err.statusCode || StatusCode.UNAUTHORIZED);
     }
@@ -208,7 +213,8 @@ export class UserController extends BaseController<IUser, UserService> {
 
   me = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
     const authHeader = getHeaderValue(event.headers || {}, "Authorization");
-    if (!authHeader?.startsWith("Bearer ")) return this.errorResponse("Missing token", StatusCode.UNAUTHORIZED);
+    if (!authHeader?.startsWith("Bearer "))
+      return this.errorResponse("Missing token", StatusCode.UNAUTHORIZED);
 
     try {
       const claims = this.jwtAuthService.verifyAccessToken(authHeader.slice(7));

--- a/server/src/controllers/userController.ts
+++ b/server/src/controllers/userController.ts
@@ -10,15 +10,18 @@ import { IUser } from "../interfaces/IUser";
 import BaseController from "./BaseController";
 import { welcomeEmailTemplate } from "../utils/emailTemplates";
 import AuthService from "../services/AuthService";
+import JwtAuthService from "../services/JwtAuthService";
 
 export class UserController extends BaseController<IUser, UserService> {
   private authService: AuthService;
   private sessionService: SessionService;
+  private jwtAuthService: JwtAuthService;
 
   constructor() {
     super(new UserService());
     this.sessionService = new SessionService();
     this.authService = new AuthService();
+    this.jwtAuthService = new JwtAuthService();
   }
 
   private validateUserAccess(user: IUser | null): APIGatewayProxyResult | null {
@@ -159,16 +162,77 @@ export class UserController extends BaseController<IUser, UserService> {
         ip,
         device,
       });
+      const user = session.data?.user;
+      const { refreshToken } = await this.jwtAuthService.createRefreshSession(user, { ip, device });
+      const accessToken = this.jwtAuthService.signAccessToken({
+        userId: user._id.toString(),
+        role: user.role,
+        sessionId: session._id?.toString(),
+      });
 
       return this.successResponse({
         status: StatusCode.OK,
-        data: session,
+        data: { accessToken, refreshToken, sessionId: session._id, user: this.toSafeUser(user) },
         message: "התחברות בוצעה בהצלחה!",
       });
     } catch (err: any) {
       return this.errorResponse(err.message, err.statusCode || StatusCode.INTERNAL_SERVER_ERROR);
     }
   };
+
+
+  refreshAuth = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+    const { refreshToken, error } = this.getParamsOrError(event, ["refreshToken"], "body");
+    if (error) return error;
+
+    try {
+      const { user } = await this.jwtAuthService.validateRefreshToken(refreshToken);
+      const accessToken = this.jwtAuthService.signAccessToken({ userId: user._id.toString(), role: user.role });
+      return this.successResponse({ status: StatusCode.OK, data: { accessToken, user: this.toSafeUser(user) } });
+    } catch (err: any) {
+      return this.errorResponse(err.message, err.statusCode || StatusCode.UNAUTHORIZED);
+    }
+  };
+
+  logoutAuth = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+    const { refreshToken, error } = this.getParamsOrError(event, ["refreshToken"], "body");
+    if (error) return error;
+
+    try {
+      await this.jwtAuthService.revokeRefreshToken(refreshToken);
+      return this.successResponse({ status: StatusCode.OK, message: "Logged out" });
+    } catch (err: any) {
+      return this.errorResponse(err.message, err.statusCode || StatusCode.UNAUTHORIZED);
+    }
+  };
+
+  me = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+    const authHeader = getHeaderValue(event.headers || {}, "Authorization");
+    if (!authHeader?.startsWith("Bearer ")) return this.errorResponse("Missing token", StatusCode.UNAUTHORIZED);
+
+    try {
+      const claims = this.jwtAuthService.verifyAccessToken(authHeader.slice(7));
+      const user = await this.service.findById(claims.userId);
+      if (!user) return this.errorResponse("Unauthorized", StatusCode.UNAUTHORIZED);
+      if (!user.hasAccess) return this.errorResponse("Unauthorized", StatusCode.FORBIDDEN);
+      return this.successResponse({ status: StatusCode.OK, data: this.toSafeUser(user) });
+    } catch (err) {
+      return this.errorResponse("Unauthorized", StatusCode.UNAUTHORIZED);
+    }
+  };
+
+  private toSafeUser(user: IUser) {
+    return {
+      id: user._id,
+      email: user.email,
+      role: user.role,
+      status: user.hasAccess ? "active" : "inactive",
+      firstName: user.firstName,
+      lastName: user.lastName,
+      isSuperAdmin: user.role === "admin",
+      isTrainer: user.role === "trainer",
+    };
+  }
 
   checkUserSessionToken = async (event: APIGatewayEvent) => {
     try {

--- a/server/src/functions/users/index.ts
+++ b/server/src/functions/users/index.ts
@@ -17,6 +17,10 @@ const userApiHandlers = {
   [`PUT ${BASE_PATH}/user/register`]: userController.register,
   [`POST ${BASE_PATH}/user/login`]: userController.logIn,
   [`POST ${BASE_PATH}/user/session`]: userController.checkUserSessionToken,
+  [`POST /auth/login`]: userController.logIn,
+  [`POST /auth/refresh`]: userController.refreshAuth,
+  [`POST /auth/logout`]: userController.logoutAuth,
+  [`GET /auth/me`]: userController.me,
 };
 
 const userValidaters = {

--- a/server/src/services/AuthService.ts
+++ b/server/src/services/AuthService.ts
@@ -19,15 +19,17 @@ class AuthService {
   ): Promise<ISession> {
     const user = await this.userService.findOne({ email: email.toLowerCase() });
 
-    if (!user) throw { message: "משתמש לא נמצא!", statusCode: StatusCode.NOT_FOUND };
+    if (!user) throw { message: "Invalid credentials", statusCode: StatusCode.UNAUTHORIZED };
     if (isAdminApp) {
       requireAdmin(user);
     }
     if (!user.hasAccess)
-      throw { message: "אין גישה לכתובת המייל", statusCode: StatusCode.UNAUTHORIZED };
+      throw { message: "User is inactive", statusCode: StatusCode.FORBIDDEN };
+    if (user.onboardingStep !== "completed")
+      throw { message: "User invite pending", statusCode: StatusCode.FORBIDDEN };
 
     const isMatch = await this.passwordsService.comparePasswords(user._id.toString(), password);
-    if (!isMatch) throw { message: "מייל או סיסמא שגויים!", statusCode: StatusCode.NOT_FOUND };
+    if (!isMatch) throw { message: "Invalid credentials", statusCode: StatusCode.UNAUTHORIZED };
 
     return this.sessionService.create({
       userId: user._id.toString(),

--- a/server/src/services/AuthService.ts
+++ b/server/src/services/AuthService.ts
@@ -23,8 +23,7 @@ class AuthService {
     if (isAdminApp) {
       requireAdmin(user);
     }
-    if (!user.hasAccess)
-      throw { message: "User is inactive", statusCode: StatusCode.FORBIDDEN };
+    if (!user.hasAccess) throw { message: "User is inactive", statusCode: StatusCode.FORBIDDEN };
     if (user.onboardingStep !== "completed")
       throw { message: "User invite pending", statusCode: StatusCode.FORBIDDEN };
 

--- a/server/src/services/JwtAuthService.ts
+++ b/server/src/services/JwtAuthService.ts
@@ -5,20 +5,94 @@ import UserRepository from "../repositories/User/UserRepository";
 import { IUser } from "../interfaces/IUser";
 
 const ACCESS_EXPIRES_IN = process.env.JWT_ACCESS_EXPIRES_IN || "15m";
-const REFRESH_EXPIRES_IN_MS = Number(process.env.JWT_REFRESH_EXPIRES_IN_MS || 1000 * 60 * 60 * 24 * 30);
-interface AccessClaims { userId: string; role: IUser["role"]; sessionId?: string; exp?: number }
+const REFRESH_EXPIRES_IN_MS = Number(
+  process.env.JWT_REFRESH_EXPIRES_IN_MS || 1000 * 60 * 60 * 24 * 30
+);
+interface AccessClaims {
+  userId: string;
+  role: IUser["role"];
+  sessionId?: string;
+  exp?: number;
+}
 
 class JwtAuthService {
   private sessionRepository = new SessionRepository();
   private userRepository = new UserRepository();
-  private getAccessSecret() { const secret = process.env.JWT_ACCESS_SECRET; if (!secret) throw { message: "Missing JWT access secret", statusCode: StatusCode.INTERNAL_SERVER_ERROR }; return secret; }
-  private parseExpiresIn(value: string) { if (value.endsWith("m")) return Number(value.slice(0, -1)) * 60; if (value.endsWith("h")) return Number(value.slice(0, -1)) * 3600; if (value.endsWith("d")) return Number(value.slice(0, -1)) * 86400; return Number(value); }
-  signAccessToken(claims: AccessClaims) { const header = Buffer.from(JSON.stringify({ alg: "HS256", typ: "JWT" })).toString("base64url"); const exp = Math.floor(Date.now() / 1000) + this.parseExpiresIn(ACCESS_EXPIRES_IN); const payload = Buffer.from(JSON.stringify({ ...claims, exp })).toString("base64url"); const sig = crypto.createHmac("sha256", this.getAccessSecret()).update(`${header}.${payload}`).digest("base64url"); return `${header}.${payload}.${sig}`; }
-  verifyAccessToken(token: string) { const parts = token.split("."); if (parts.length !== 3) throw new Error("Malformed token"); const [header, payload, signature] = parts; const expected = crypto.createHmac("sha256", this.getAccessSecret()).update(`${header}.${payload}`).digest("base64url"); if (expected !== signature) throw new Error("Invalid token"); const parsed = JSON.parse(Buffer.from(payload, "base64url").toString("utf8")); if (!parsed.exp || parsed.exp < Math.floor(Date.now() / 1000)) throw new Error("Expired token"); return parsed as AccessClaims; }
-  hashToken(token: string) { return crypto.createHash("sha256").update(token).digest("hex"); }
-  async createRefreshSession(user: IUser, metadata: { ip?: string; device?: string } = {}) { const rawToken = crypto.randomBytes(48).toString("hex"); const tokenHash = this.hashToken(rawToken); const expiresAt = new Date(Date.now() + REFRESH_EXPIRES_IN_MS); const session = await this.sessionRepository.create({ userId: user._id.toString(), type: "auth_refresh", data: { tokenHash, ip: metadata.ip, device: metadata.device, expiresAt, revokedAt: null } } as any); return { refreshToken: rawToken, session }; }
-  async validateRefreshToken(refreshToken: string) { const tokenHash = this.hashToken(refreshToken); const session = await this.sessionRepository.findOne({ query: { type: "auth_refresh", "data.tokenHash": tokenHash } as any }); if (!session) throw { message: "Invalid refresh token", statusCode: StatusCode.UNAUTHORIZED }; if (session.data?.revokedAt) throw { message: "Refresh token revoked", statusCode: StatusCode.UNAUTHORIZED }; if (!session.data?.expiresAt || new Date(session.data.expiresAt).getTime() <= Date.now()) throw { message: "Refresh token expired", statusCode: StatusCode.UNAUTHORIZED }; const user = await this.userRepository.findById(session.userId); if (!user) throw { message: "User not found", statusCode: StatusCode.UNAUTHORIZED }; if (!user.hasAccess) throw { message: "User inactive", statusCode: StatusCode.FORBIDDEN }; return { session, user }; }
-  async revokeRefreshToken(refreshToken: string) { const tokenHash = this.hashToken(refreshToken); const session = await this.sessionRepository.findOne({ query: { type: "auth_refresh", "data.tokenHash": tokenHash } as any }); if (!session) return; await this.sessionRepository.updateById(session._id!.toString(), { update: { data: { ...session.data, revokedAt: new Date() }, updatedAt: new Date() } as any, options: { new: true } }); }
+  private getAccessSecret() {
+    const secret = process.env.JWT_ACCESS_SECRET;
+    if (!secret)
+      throw { message: "Missing JWT access secret", statusCode: StatusCode.INTERNAL_SERVER_ERROR };
+    return secret;
+  }
+  private parseExpiresIn(value: string) {
+    if (value.endsWith("m")) return Number(value.slice(0, -1)) * 60;
+    if (value.endsWith("h")) return Number(value.slice(0, -1)) * 3600;
+    if (value.endsWith("d")) return Number(value.slice(0, -1)) * 86400;
+    return Number(value);
+  }
+  signAccessToken(claims: AccessClaims) {
+    const header = Buffer.from(JSON.stringify({ alg: "HS256", typ: "JWT" })).toString("base64url");
+    const exp = Math.floor(Date.now() / 1000) + this.parseExpiresIn(ACCESS_EXPIRES_IN);
+    const payload = Buffer.from(JSON.stringify({ ...claims, exp })).toString("base64url");
+    const sig = crypto
+      .createHmac("sha256", this.getAccessSecret())
+      .update(`${header}.${payload}`)
+      .digest("base64url");
+    return `${header}.${payload}.${sig}`;
+  }
+  verifyAccessToken(token: string) {
+    const parts = token.split(".");
+    if (parts.length !== 3) throw new Error("Malformed token");
+    const [header, payload, signature] = parts;
+    const expected = crypto
+      .createHmac("sha256", this.getAccessSecret())
+      .update(`${header}.${payload}`)
+      .digest("base64url");
+    if (expected !== signature) throw new Error("Invalid token");
+    const parsed = JSON.parse(Buffer.from(payload, "base64url").toString("utf8"));
+    if (!parsed.exp || parsed.exp < Math.floor(Date.now() / 1000)) throw new Error("Expired token");
+    return parsed as AccessClaims;
+  }
+  hashToken(token: string) {
+    return crypto.createHash("sha256").update(token).digest("hex");
+  }
+  async createRefreshSession(user: IUser, metadata: { ip?: string; device?: string } = {}) {
+    const rawToken = crypto.randomBytes(48).toString("hex");
+    const tokenHash = this.hashToken(rawToken);
+    const expiresAt = new Date(Date.now() + REFRESH_EXPIRES_IN_MS);
+    const session = await this.sessionRepository.create({
+      userId: user._id.toString(),
+      type: "auth_refresh",
+      data: { tokenHash, ip: metadata.ip, device: metadata.device, expiresAt, revokedAt: null },
+    } as any);
+    return { refreshToken: rawToken, session };
+  }
+  async validateRefreshToken(refreshToken: string) {
+    const tokenHash = this.hashToken(refreshToken);
+    const session = await this.sessionRepository.findOne({
+      query: { type: "auth_refresh", "data.tokenHash": tokenHash } as any,
+    });
+    if (!session) throw { message: "Invalid refresh token", statusCode: StatusCode.UNAUTHORIZED };
+    if (session.data?.revokedAt)
+      throw { message: "Refresh token revoked", statusCode: StatusCode.UNAUTHORIZED };
+    if (!session.data?.expiresAt || new Date(session.data.expiresAt).getTime() <= Date.now())
+      throw { message: "Refresh token expired", statusCode: StatusCode.UNAUTHORIZED };
+    const user = await this.userRepository.findById(session.userId);
+    if (!user) throw { message: "User not found", statusCode: StatusCode.UNAUTHORIZED };
+    if (!user.hasAccess) throw { message: "User inactive", statusCode: StatusCode.FORBIDDEN };
+    return { session, user };
+  }
+  async revokeRefreshToken(refreshToken: string) {
+    const tokenHash = this.hashToken(refreshToken);
+    const session = await this.sessionRepository.findOne({
+      query: { type: "auth_refresh", "data.tokenHash": tokenHash } as any,
+    });
+    if (!session) return;
+    await this.sessionRepository.updateById(session._id!.toString(), {
+      update: { data: { ...session.data, revokedAt: new Date() }, updatedAt: new Date() } as any,
+      options: { new: true },
+    });
+  }
 }
 
 export default JwtAuthService;

--- a/server/src/services/JwtAuthService.ts
+++ b/server/src/services/JwtAuthService.ts
@@ -1,0 +1,24 @@
+import crypto from "crypto";
+import { StatusCode } from "../enums/StatusCode";
+import { SessionRepository } from "../repositories/Sessions/SessionRepository";
+import UserRepository from "../repositories/User/UserRepository";
+import { IUser } from "../interfaces/IUser";
+
+const ACCESS_EXPIRES_IN = process.env.JWT_ACCESS_EXPIRES_IN || "15m";
+const REFRESH_EXPIRES_IN_MS = Number(process.env.JWT_REFRESH_EXPIRES_IN_MS || 1000 * 60 * 60 * 24 * 30);
+interface AccessClaims { userId: string; role: IUser["role"]; sessionId?: string; exp?: number }
+
+class JwtAuthService {
+  private sessionRepository = new SessionRepository();
+  private userRepository = new UserRepository();
+  private getAccessSecret() { const secret = process.env.JWT_ACCESS_SECRET; if (!secret) throw { message: "Missing JWT access secret", statusCode: StatusCode.INTERNAL_SERVER_ERROR }; return secret; }
+  private parseExpiresIn(value: string) { if (value.endsWith("m")) return Number(value.slice(0, -1)) * 60; if (value.endsWith("h")) return Number(value.slice(0, -1)) * 3600; if (value.endsWith("d")) return Number(value.slice(0, -1)) * 86400; return Number(value); }
+  signAccessToken(claims: AccessClaims) { const header = Buffer.from(JSON.stringify({ alg: "HS256", typ: "JWT" })).toString("base64url"); const exp = Math.floor(Date.now() / 1000) + this.parseExpiresIn(ACCESS_EXPIRES_IN); const payload = Buffer.from(JSON.stringify({ ...claims, exp })).toString("base64url"); const sig = crypto.createHmac("sha256", this.getAccessSecret()).update(`${header}.${payload}`).digest("base64url"); return `${header}.${payload}.${sig}`; }
+  verifyAccessToken(token: string) { const parts = token.split("."); if (parts.length !== 3) throw new Error("Malformed token"); const [header, payload, signature] = parts; const expected = crypto.createHmac("sha256", this.getAccessSecret()).update(`${header}.${payload}`).digest("base64url"); if (expected !== signature) throw new Error("Invalid token"); const parsed = JSON.parse(Buffer.from(payload, "base64url").toString("utf8")); if (!parsed.exp || parsed.exp < Math.floor(Date.now() / 1000)) throw new Error("Expired token"); return parsed as AccessClaims; }
+  hashToken(token: string) { return crypto.createHash("sha256").update(token).digest("hex"); }
+  async createRefreshSession(user: IUser, metadata: { ip?: string; device?: string } = {}) { const rawToken = crypto.randomBytes(48).toString("hex"); const tokenHash = this.hashToken(rawToken); const expiresAt = new Date(Date.now() + REFRESH_EXPIRES_IN_MS); const session = await this.sessionRepository.create({ userId: user._id.toString(), type: "auth_refresh", data: { tokenHash, ip: metadata.ip, device: metadata.device, expiresAt, revokedAt: null } } as any); return { refreshToken: rawToken, session }; }
+  async validateRefreshToken(refreshToken: string) { const tokenHash = this.hashToken(refreshToken); const session = await this.sessionRepository.findOne({ query: { type: "auth_refresh", "data.tokenHash": tokenHash } as any }); if (!session) throw { message: "Invalid refresh token", statusCode: StatusCode.UNAUTHORIZED }; if (session.data?.revokedAt) throw { message: "Refresh token revoked", statusCode: StatusCode.UNAUTHORIZED }; if (!session.data?.expiresAt || new Date(session.data.expiresAt).getTime() <= Date.now()) throw { message: "Refresh token expired", statusCode: StatusCode.UNAUTHORIZED }; const user = await this.userRepository.findById(session.userId); if (!user) throw { message: "User not found", statusCode: StatusCode.UNAUTHORIZED }; if (!user.hasAccess) throw { message: "User inactive", statusCode: StatusCode.FORBIDDEN }; return { session, user }; }
+  async revokeRefreshToken(refreshToken: string) { const tokenHash = this.hashToken(refreshToken); const session = await this.sessionRepository.findOne({ query: { type: "auth_refresh", "data.tokenHash": tokenHash } as any }); if (!session) return; await this.sessionRepository.updateById(session._id!.toString(), { update: { data: { ...session.data, revokedAt: new Date() }, updatedAt: new Date() } as any, options: { new: true } }); }
+}
+
+export default JwtAuthService;

--- a/server/tests/auth-jwt-foundation.test.ts
+++ b/server/tests/auth-jwt-foundation.test.ts
@@ -1,0 +1,31 @@
+import JwtAuthService from "../src/services/JwtAuthService";
+
+describe("JwtAuthService", () => {
+  const service = new JwtAuthService();
+  beforeAll(() => {
+    process.env.JWT_ACCESS_SECRET = "test-secret";
+    process.env.JWT_ACCESS_EXPIRES_IN = "1";
+  });
+
+  test("signs and verifies token", () => {
+    const token = service.signAccessToken({ userId: "u1", role: "admin" });
+    const claims = service.verifyAccessToken(token);
+    expect(claims.userId).toBe("u1");
+    expect(claims.role).toBe("admin");
+  });
+
+  test("rejects malformed token", () => {
+    expect(() => service.verifyAccessToken("bad")).toThrow();
+  });
+
+  test("rejects expired token", async () => {
+    const token = service.signAccessToken({ userId: "u1", role: "admin" });
+    await new Promise((r) => setTimeout(r, 1200));
+    expect(() => service.verifyAccessToken(token)).toThrow();
+  });
+
+  test("hashes refresh tokens deterministically", () => {
+    expect(service.hashToken("abc")).toBe(service.hashToken("abc"));
+    expect(service.hashToken("abc")).not.toBe(service.hashToken("abd"));
+  });
+});


### PR DESCRIPTION
### Motivation
- Prepare the backend for a future multi-tenant Super Admin / Trainer platform by implementing a secure JWT-based authentication foundation. 
- Ensure access tokens prove identity only (minimal claims) while the DB remains the source of truth for user status and revocation. 
- Provide extension points for future middleware (`requireAuth`, `requireRole`, permissions and trainer-scoped checks) without changing resource/permission models yet.

### Description
- Added a new `JwtAuthService` (`server/src/services/JwtAuthService.ts`) that issues HMAC-signed short-lived access tokens, verifies tokens (malformed/signature/expiry checks), generates opaque refresh tokens (random + SHA-256 hashed), validates refresh sessions, and revokes refresh sessions on logout. 
- Hardened `AuthService` (`server/src/services/AuthService.ts`) to normalize emails, return generic invalid-credentials errors, and block users by existing flags (`hasAccess` and `onboardingStep`) during normal login. 
- Extended `UserController` (`server/src/controllers/userController.ts`) to: return `accessToken` + `refreshToken` + safe user projection on login, implement `POST /auth/refresh`, `POST /auth/logout`, and `GET /auth/me`, and add a `toSafeUser` projection that exposes only safe profile/role/status fields. 
- Wired the new endpoints into the lambda routing map (`server/src/functions/users/index.ts`), added docs `server/docs/auth-jwt-implementation.md`, and added unit tests `server/tests/auth-jwt-foundation.test.ts` covering token signing/verification, malformed/expired tokens, and refresh-token hashing determinism.

### Testing
- Added unit tests in `server/tests/auth-jwt-foundation.test.ts` and ran `npm test` for that suite locally. 
- The new unit tests exercise `JwtAuthService.signAccessToken`, `verifyAccessToken`, expiry behavior, and `hashToken`, but the local test run failed due to an existing TypeScript compilation issue in the repository baseline (`src/repositories/BaseRepository.ts`) unrelated to the auth changes. 
- No other automated tests were modified; integration endpoint tests were not added in this change and are planned as follow-ups once the repo-type errors are resolved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8be30b5dc832b9465dcf4153b3e24)